### PR TITLE
Use vault_port+1 in cluster_addr for HA vault

### DIFF
--- a/templates/vault_backend_consul.j2
+++ b/templates/vault_backend_consul.j2
@@ -1,6 +1,6 @@
 backend "consul" {
   address = "{{ vault_consul }}"
   redirect_addr = "http://{{ vault_redirect_addr }}:{{ vault_port }}"
-  cluster_addr = "http://{{ vault_primary_node }}:{{ vault_port }}/"
+  cluster_addr = "http://{{ vault_primary_node }}:{{ vault_port+1|int|abs }}/"
   path = "vault"
 }


### PR DESCRIPTION
https://www.vaultproject.io/docs/concepts/ha.html#per-node-cluster-listener-addresses

### Per-Node Cluster Listener Addresses

Each listener block in Vault's configuration file contains an address value on which Vault listens for requests. Similarly, each listener block can contain a cluster_address on which Vault listens for server-to-server cluster requests. If this value is not set, its IP address will be automatically set to same as the address value, and its port will be automatically set to the same as the address value plus one (so by default, port 8201).

Note that only active nodes have active listeners. When a node becomes active it will start cluster listeners, and when it becomes standby it will stop them.