### PR TITLE
Correct syntax error in 'Add Vault User'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
   group_by:
     key: "{{ vault_node_role }}"
 
-- name: "Add Vault user
+- name: "Add Vault user"
   user:
     name: "{{ vault_user }}"
     comment: "Vault user"


### PR DESCRIPTION
The error appears to have been in '/tmp/ansible/playbooks/roles/brianshumate.vault/tasks/main.yml': line 34, column 12, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  user:
    name: "{{ vault_user }}"
           ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes.  Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"