### PR TITLE
TLS: Quote mode in with_items

### DIFF
--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -11,9 +11,9 @@
   with_items:
     - src:  "{{ vault_tls_cert_file }}"
       dest: "{{ vault_tls_cert_file_dest }}"
-      mode: 0644
+      mode: "0644"
     - src:  "{{ vault_tls_key_file }}"
       dest: "{{ vault_tls_key_file_dest }}"
-      mode: 0600
+      mode: "0600"
   # These checks fail even though there are no values for the vars
   when: vault_tls_cert_file is defined and vault_tls_key_file is defined


### PR DESCRIPTION
The mode is being interpreted as decimal rather than octal when expanded.
Quoting ensures that the mode is no longer cast.