### PR TITLE
Fix Missing Defaults for TLS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,9 +67,9 @@ vault_tls_key_file: "../files/{{ vault_node_name }}.key"
 # "/etc/pki/tls/private/vault.key" is distribution-specific/not a good default
 # a distribution-specific play to link into expected destination is preferred
 vault_tls_key_file_dest: "{{ vault_tls_config_path }}/vault.key"
-vault_tls_min_version: "{{ lookup('env','VAULT_TLS_MIN_VERSION') | default('tls12') }}"
+vault_tls_min_version: "{{ lookup('env','VAULT_TLS_MIN_VERSION') | default('tls12', true) }}"
 vault_tls_cipher_suites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA"
-vault_tls_prefer_server_cipher_suites: "{{ lookup('env','VAULT_TLS_PREFER_SERVER_CIPHER_SUITES') | default('false') }}"
+vault_tls_prefer_server_cipher_suites: "{{ lookup('env','VAULT_TLS_PREFER_SERVER_CIPHER_SUITES') | default('false', true) }}"
 
 ## Vault Enterprise
 


### PR DESCRIPTION
Given that `vault_tls_min_version` and `vault_tls_prefer_server_cipher_suites` will evaluate to false, make sure the defaults are populated