### PR TITLE
add missing restart case in the debian init script

### DIFF
--- a/templates/vault_debian.init.j2
+++ b/templates/vault_debian.init.j2
@@ -87,6 +87,7 @@ case "$1" in
         2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
     esac
     ;;
+  restart)
     log_daemon_msg "Restarting $DESC" "$NAME"
     do_stop
     case "$?" in


### PR DESCRIPTION
Hello!

Thanks for this nice role!
I tried to use it with Ubuntu 14.04 and found a missing `restart)` case in the Debian init script:

Error message:

```
{"changed": false, "failed": true, "msg": "/etc/init.d/vault: 90: /etc/init.d/vault: Syntax error: word unexpected (expecting \")\")\n"}
```

After adding the restart case the role succeeds.