### PR TITLE
Use status command to check the daemon state in the debian init script

### DIFF
--- a/templates/vault_debian.init.j2
+++ b/templates/vault_debian.init.j2
@@ -45,8 +45,11 @@ do_start() {
             sleep 1
             continue
         fi
-        if "$DAEMON" info >/dev/null; then
+
+        if "$DAEMON" status >/dev/null; then
             return 0
+        else
+          RETVAL=2
         fi
     done
     return "$RETVAL"


### PR DESCRIPTION
## Problem

`vault info` command does not exist and therefore the init script fails with:

`/etc/init.d/vault: 53: return: Illegal number:`

after printing vault cli help message 30 times:

```
usage: vault [-version] [-help] <command> [args]

Common commands:
    delete           Delete operation on secrets in Vault
    path-help        Look up the help for a path
    read             Read data or secrets from Vault
    renew            Renew the lease of a secret
    revoke           Revoke a secret.
    server           Start a Vault server
    status           Outputs status of whether Vault is sealed and if HA mode is enabled
    unwrap           Unwrap a wrapped secret
    write            Write secrets or configuration into Vault

All other commands:
    audit-disable    Disable an audit backend
    audit-enable     Enable an audit backend
    audit-list       Lists enabled audit backends in Vault
    auth             Prints information about how to authenticate with Vault
    auth-disable     Disable an auth provider
    auth-enable      Enable a new auth provider
    capabilities     Fetch the capabilities of a token on a given path
    generate-root    Generates a new root token
    init             Initialize a new Vault server
    key-status       Provides information about the active encryption key
    list             List data or secrets in Vault
    mount            Mount a logical backend
    mount-tune       Tune mount configuration parameters
    mounts           Lists mounted backends in Vault
    policies         List the policies on the server
    policy-delete    Delete a policy from the server
    policy-write     Write a policy to the server
    rekey            Rekeys Vault to generate new unseal keys
    remount          Remount a secret backend to a new path
    rotate           Rotates the backend encryption key used to persist data
    seal             Seals the Vault server
    ssh              Initiate an SSH session
    step-down        Force the Vault node to give up active duty
    token-create     Create a new auth token
    token-lookup     Display information about the specified token
    token-renew      Renew an auth token if there is an associated lease
    token-revoke     Revoke one or more auth tokens
    unmount          Unmount a secret backend
    unseal           Unseals the Vault server
    version          Prints the Vault version
```

This error message happens because `RETVAL` is not set if `vault info` returns non-zero code.

## Solution

1. use `vault status` command instead of `vault info`
2. set `RETVAL=2` if `vault status` fails