### PR TITLE
Remove vault status check from the debian script

### DIFF
--- a/templates/vault_debian.init.j2
+++ b/templates/vault_debian.init.j2
@@ -39,17 +39,12 @@ do_start() {
         $DAEMON_ARGS \
         || return 2
 
+    RETVAL=0
     for i in `seq 1 30`; do
         if ! start-stop-daemon --quiet --stop --test --pidfile $PIDFILE --exec $DAEMON --user $USER; then
             RETVAL=2
             sleep 1
             continue
-        fi
-
-        if "$DAEMON" status >/dev/null; then
-            return 0
-        else
-          RETVAL=2
         fi
     done
     return "$RETVAL"


### PR DESCRIPTION
There are 2 problems with the `vault status` check in the debian init script right now:

* If Vault is being installed for the first time, it is sealed and `vault status` will return non-zero exit which in turn will make the init script return non-zero exit code
* With configured TLS calling `vault status` without specifying Vault's public address or domain name used in the certificate will end up in the certificate check error

Also, this check does not exist in the daemon scripts for the other platforms, so removing it unifies the behavior.

---
Sorry for multiple PRs to the same file changing the behavior, I hope it does not annoy you too much :)