### PR TITLE
Fix is Vault api reachable task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,8 +113,12 @@
     state: started
     enabled: yes
 
+- name: Restart Vault if needed
+  meta: flush_handlers
+
 - name: Vault API reachable?
   wait_for:
-    host: "{{ vault_address}}"
+    host: "{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}"
     port: "{{ vault_port }}"
     delay: "10"
+    timeout: "60"


### PR DESCRIPTION
Fixed the task: "Vault API reachable?" for the following cases:

- `vault_address ` is set to `0.0.0.0` -> in this case, the request is made to `127.0.0.1`
- There was changes in the listen address in the configuration, in that case it would be necessary to restart vault first.
- Added a timeout of 1 minute.