### PR TITLE
improve TLS features and add vault enterprise download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The role defines variables in `defaults/main.yml`:
 
 - Package download URL
 - Default value: `"https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version }}_linux_amd64.zip"`
+- Override this var if you have your zip hosted locally
+- Works for enterprise installs also
 
 ### `vault_checksum_file_url`
 
@@ -436,7 +438,7 @@ The role can install Vault Enterprise based instances.
 
 Place the Vault Enterprise zip archive into `{{ role_path }}/files` and set
 `vault_enterprise: true` or use the `VAULT_ENTERPRISE="true"` environment
-variable.
+variable. Attempts to download the package from `vault_zip_url` if zip is not found in files/.
 
 ### `vault_enterprise_premium`
 

--- a/README.md
+++ b/README.md
@@ -246,25 +246,39 @@ The role defines variables in `defaults/main.yml`:
   - Can be overridden with `VAULT_TLS_DISABLE` environment variable
 - Default value: *1*
 
-### `vault_tls_cert_file`
+### `vault_tls_gossip`
 
-- [Vault TLS certificate file path](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_cert_file)
-- Default value: None
+- Enable TLS Gossip to Consul Backend
+- Default value: *0*
 
-### `vault_tls_cert_file_dest`
+### `vault_tls_src_files`
 
-- Vault TLS certificate destination (full path)
-- Default value: `"{{ vault_tls_config_path }}/vault.crt" # /etc/pki/tls/certs/vault.crt`
+- User-specified source directory for TLS files
+  - Override with `VAULT_TLS_SRC_FILES` environment variable
+- Default value: `{{ role_path }}/files`
+
+### `vault_tls_config_path`
+
+- Path to TLS certificate and key
+- Default value `/etc/vault/tls`
+
+### `vault_tls_ca_file`
+
+- CA certificate filename
+  - Override with `VAULT_TLS_CA_CRT` environment variable
+- Default value: `ca.crt`
+
+### `vault_tls_server_crt_file`
+
+- Server certificate
+  - Override with `VAULT_TLS_SERVER_CRT` environment variable
+- Default value: `server.crt`
 
 ### `vault_tls_key_file`
 
-- [Vault TLS key file path](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_key_file)
-- Default value: None
-
-### `vault_tls_key_file_dest`
-
-- Vault TLS key destination (full path)
-- Default value: `"{{ vault_tls_config_path }}/vault.key"`
+- Server key
+  - Override with `VAULT_TLS_SERVER_KEY` environment variable
+- Default value: `server.key`
 
 ### `vault_tls_min_version`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,17 +72,19 @@ vault_consul_scheme: http
 # self-signed certificates you might need to change the below to false
 validate_certs_during_api_reachable_check: true
 
-vault_tls_config_path: /etc/vault/tls
+vault_tls_config_path: "{{ lookup('env','VAULT_TLS_DIR') | default('/etc/vault/tls', true) }}"
+vault_tls_src_files: "{{ lookup('env','VAULT_TLS_SRC_FILES') | default(role_path+'/files', true) }}"
+
 vault_tls_disable: "{{ lookup('env','VAULT_TLS_DISABLE') | default(1, true) }}"
+vault_tls_gossip: "{{ lookup('env','VAULT_TLS_GOSSIP') | default(0, true) }}"
+
 vault_protocol: "{% if vault_tls_disable %}http{% else %}https{% endif %}"
-vault_tls_cert_file: "../files/{{ vault_node_name }}.crt"
-# /etc/pki/tls/certs/vault.crt is distribution-specific/not a good default
+vault_tls_cert_file: "{{ lookup('env','VAULT_TLS_SERVER_CRT') | default('vault.crt', true) }}"
+vault_tls_key_file: "{{ lookup('env','VAULT_TLS_SERVER_KEY') | default('vault.key', true) }}"
+vault_tls_ca_file: "{{ lookup('env','VAULT_TLS_CA_CRT') | default('ca.crt', true) }}"
+# /etc/pki/tls/certs/server.crt is distribution-specific/not a good default
 # a distribution-specific play to link into expected destination is preferred
-vault_tls_cert_file_dest: "{{ vault_tls_config_path }}/vault.crt"
-vault_tls_key_file: "../files/{{ vault_node_name }}.key"
-# "/etc/pki/tls/private/vault.key" is distribution-specific/not a good default
-# a distribution-specific play to link into expected destination is preferred
-vault_tls_key_file_dest: "{{ vault_tls_config_path }}/vault.key"
+
 vault_tls_min_version: "{{ lookup('env','VAULT_TLS_MIN_VERSION') | default('tls12', true) }}"
 vault_tls_cipher_suites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA"
 vault_tls_prefer_server_cipher_suites: "{{ lookup('env','VAULT_TLS_PREFER_SERVER_CIPHER_SUITES') | default('false', true) }}"

--- a/tasks/install_enterprise.yml
+++ b/tasks/install_enterprise.yml
@@ -28,6 +28,13 @@
   run_once: true
   register: vault_package
 
+- name: "[Enterprise] Download vault version {{ vault_version }}"
+  local_action: get_url  url={{ vault_zip_url }} dest={{ role_path }}/files/{{ vault_pkg }} checksum=sha256:{{ vault_sha256.stdout }} timeout=42
+  become: no
+  run_once: true
+  tags: installation
+  when: not vault_package.stat.exists | bool
+
 - name: "[Enterprise] Unzip {{ role_path }}/files/{{ vault_enterprise_pkg }}"
   local_action: unarchive src="{{ role_path }}/files/{{ vault_enterprise_pkg }}" dest="{{ role_path }}/files/" creates="{{ role_path }}/files/vault"
   become: no

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -25,3 +25,6 @@
     - src:  "{{ vault_tls_key_file }}"
       dest: "{{ vault_tls_key_file_dest }}"
       mode: "0600"
+    - src:  "{{ vault_tls_src_files}}/{{ vault_tls_ca_file }}"
+      dest: "{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+      mode: "0644"

--- a/templates/vault_backend_consul.j2
+++ b/templates/vault_backend_consul.j2
@@ -8,8 +8,14 @@ backend "consul" {
   cluster_addr = "{{vault_protocol}}://{{ vault_cluster_address }}:{{ _vault_plus_one_port }}"
   redirect_addr = "{{vault_protocol}}://{{ vault_redirect_address }}:{{ vault_port }}"
   disable_clustering = "{{ vault_cluster_disable }}"
-{% if vault_consul_token is defined and vault_consul_token %}
+  {% if vault_consul_token is defined and vault_consul_token %}
   token = "{{ vault_consul_token }}"
-{% endif %}
+  {% endif %}
   scheme = "{{ vault_consul_scheme }}"
+  {% if vault_tls_gossip %}
+  tls_cert_file = "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
+  tls_key_file = "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
+  tls_ca_file="{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+  {% endif %}
+
 }

--- a/templates/vault_listener.hcl.j2
+++ b/templates/vault_listener.hcl.j2
@@ -5,13 +5,14 @@ default_lease_ttl = "{{ vault_default_lease_ttl }}"
 listener "tcp" {
   address = "{{ vault_address }}:{{ vault_port }}"
   {% if not (vault_tls_disable | bool) -%}
-    tls_cert_file = "{{ vault_tls_cert_file_dest }}"
-    tls_key_file  = "{{ vault_tls_key_file_dest }}"
-    tls_min_version  = "{{ vault_tls_min_version }}"
-    {% if vault_tls_cipher_suites is defined and vault_tls_cipher_suites -%}
-      tls_cipher_suites = "{{ vault_tls_cipher_suites}}"
-    {% endif -%}
-    tls_prefer_server_cipher_suites = "{{ vault_tls_prefer_server_cipher_suites }}"
+  tls_cert_file = "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
+  tls_key_file = "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
+  tls_client_ca_file="{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+  tls_min_version  = "{{ vault_tls_min_version }}"
+  {% if vault_tls_cipher_suites is defined and vault_tls_cipher_suites -%}
+  tls_cipher_suites = "{{ vault_tls_cipher_suites}}"
+  {% endif -%}
+  tls_prefer_server_cipher_suites = "{{ vault_tls_prefer_server_cipher_suites }}"
   {% endif -%}
   tls_disable = "{{ vault_tls_disable | bool | lower }}"
 }
@@ -19,5 +20,5 @@ listener "tcp" {
 {% include vault_backend with context %}
 
 {% if vault_ui -%}
-  ui = {{ vault_ui | bool | lower }}
+ ui = {{ vault_ui | bool | lower }}
 {% endif -%}


### PR DESCRIPTION
Added CA file location to TLS listener in vault config

Added ability to enable TLS gossip between vault and consul

Cleaned up spacing on config file entries

Added vault enterprise download when the zips are not found locally. This will allow internally hosting rather than placing the file on the ansible local host

Cleaned up some TLS var names for cleaner cert deployment. some file deployments were named as part of the path, this is confusing and easier to maintain when separated out.