### PR TITLE
Avoid unneeded installation tasks run

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,23 +15,42 @@
 - name: Include OS-specific variables
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Check Vault installation
+  command: which vault
+  register: vault_installation
+  changed_when: False
+  ignore_errors: True
+
+- name: Get installed Vault version
+  shell: "{{ vault_installation.stdout }} -version | cut -d' ' -f2 | tr -d 'v'"
+  when: not vault_installation is failed
+  changed_when: False
+  register: installed_vault_version
+
+- name: Compute if installation is required
+  set_fact:
+    installation_required: "{{ vault_installation is failed or installed_vault_version.stdout != vault_version }}"
+
 - name: Install OS packages and Vault Enterprise via control host
   include: install_enterprise.yml
   when:
     - vault_enterprise | bool
     - not vault_install_remotely | bool
+    - installation_required | bool
 
 - name: Install OS packages and Vault via control host
   include: install.yml
   when:
     - not vault_enterprise | bool
     - not vault_install_remotely | bool
+    - installation_required | bool
 
 - name: Install OS packages and Vault via remote hosts
   include: install_remote.yml
   when:
     - not vault_enterprise | bool
     - vault_install_remotely | bool
+    - installation_required | bool
 
 - name: Enable non root mlock capability
   command: "setcap cap_ipc_lock=+ep {{ vault_bin_path }}/vault"


### PR DESCRIPTION
Don't run installation tasks when Vault is already installed with the
required version.
This is to prevent playbook runs to report unwanted changes.