### PR TITLE
Fix consul backend template

### DIFF
--- a/templates/vault_backend_consul.j2
+++ b/templates/vault_backend_consul.j2
@@ -12,7 +12,7 @@ backend "consul" {
   token = "{{ vault_consul_token }}"
   {% endif %}
   scheme = "{{ vault_consul_scheme }}"
-  {% if vault_tls_gossip %}
+  {% if vault_tls_gossip | bool %}
   tls_cert_file = "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
   tls_key_file = "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
   tls_ca_file="{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"


### PR DESCRIPTION
vault_tls_gossip is evaluated as a string and is considered true even if
it holds 0.