### PR TITLE
Add client cert validation options to listener config

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,17 @@ The role defines variables in `defaults/main.yml`:
   - Can be overridden with `VAULT_TLS_PREFER_SERVER_CIPHER_SUITES` environment variable
 - Default value: *false*
 
+### `vault_tls_require_and_verify_client_cert`
+
+- [Require clients to present a valid client certificate](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_require_and_verify_client_cert)
+- Default value: *false*
+
+### `vault_tls_disable_client_certs`
+
+- [Disable requesting for client certificates](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_disable_client_certs)
+- Default value: *false*
+
+
 ### `vault_tls_files_remote_src`
 
 - Copy from remote source if TLS files are already on host

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,6 +91,8 @@ vault_tls_min_version: "{{ lookup('env','VAULT_TLS_MIN_VERSION') | default('tls1
 vault_tls_cipher_suites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA"
 vault_tls_prefer_server_cipher_suites: "{{ lookup('env','VAULT_TLS_PREFER_SERVER_CIPHER_SUITES') | default('false', true) }}"
 vault_tls_files_remote_src: false
+vault_tls_require_and_verify_client_cert: false
+vault_tls_disable_client_certs: false
 
 ## Vault Enterprise
 

--- a/templates/vault_listener.hcl.j2
+++ b/templates/vault_listener.hcl.j2
@@ -18,6 +18,12 @@ listener "tcp" {
   tls_cipher_suites = "{{ vault_tls_cipher_suites}}"
   {% endif -%}
   tls_prefer_server_cipher_suites = "{{ vault_tls_prefer_server_cipher_suites }}"
+  {% if (vault_tls_require_and_verify_client_cert | bool) -%}
+  tls_require_and_verify_client_cert = "{{ vault_tls_require_and_verify_client_cert | bool | lower}}"
+  {% endif -%}
+  {% if (vault_tls_disable_client_certs | bool) -%}
+  tls_disable_client_certs = "{{ vault_tls_disable_client_certs | bool | lower}}"
+  {% endif -%}
   {% endif -%}
   tls_disable = "{{ vault_tls_disable | bool | lower }}"
 }


### PR DESCRIPTION
This PR allows a couple additional options to specify in the TCP listener block of the vault configuration file related to client certificate validation.

Specifically:
`tls_require_and_verify_client_cert`
https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_require_and_verify_client_cert

`tls_disable_client_certs`
https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_disable_client_certs