### PR TITLE
Allow overriding of templates in tasks/main.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ The role defines variables in `defaults/main.yml`:
 - Main configuration file name (full path)
 - Default value: `"{{ vault_config_path }}/vault_main.hcl"`
 
+### `vault_listener_template`
+- Vault listener configuration template file
+- Default value: *vault_listener.hcl.j2*
+
 ### `vault_backend_consul`
 
 - Backend consul template filename
@@ -323,6 +327,22 @@ The role defines variables in `defaults/main.yml`:
 - Copy from remote source if TLS files are already on host
 - Default value: *no*
 
+### `vault_bsdinit_template`
+- BSD init template file 
+- Default value: *vault_bsdinit.j2*
+
+### `vault_sysvinit_template`
+- SysV init  template file
+- Default value: *vault_sysvinit.j2*
+
+### `vault_debian_init_template`
+- Debian init template file
+- Default value: *vault_debian.init.j2*
+
+### `vault_systemd_template`
+- Systemd service template file
+- Default value: *vault_systemd.service.j2*
+
 ## OS Distribution Variables
 
 The `consul` binary works on most Linux platforms and is not distribution
@@ -411,6 +431,11 @@ differences across distributions:
 
 - Determines how frequently to rotate vault logs
 - Default value: *7*
+
+### `vault_logrotate_template`
+
+- Logrotate template file
+- Default value: *vault_logrotate.j2*
 
 ### `vault_ubuntu_os_packages`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ vault_group: bin
 ### Logging
 vault_enable_logrotate: false
 vault_logrotate_freq: 7
+vault_logrotate_template: vault_logrotate.j2
 
 ### Vault settings
 vault_group_name: vault_instances
@@ -51,6 +52,7 @@ vault_ui: "{{ lookup('env', 'VAULT_UI') | default(false, true) }}"
 vault_port: 8200
 vault_node_name: "{{ inventory_hostname_short }}"
 vault_main_config: "{{ vault_config_path }}/vault_main.hcl"
+vault_listener_template: vault_listener.hcl.j2
 vault_backend_consul: vault_backend_consul.j2
 vault_cluster_disable: false
 vault_cluster_address: "{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"
@@ -67,6 +69,12 @@ vault_consul_path: vault
 vault_consul_service: vault
 vault_consul_scheme: http
 # vault_consul_token:
+
+### Init templates
+vault_bsdinit_template: vault_bsdinit.j2
+vault_sysvinit_template: vault_sysvinit.j2
+vault_debian_init_template: vault_debian.init.j2
+vault_systemd_template: vault_systemd.service.j2
 
 ## TLS
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,7 @@
 
 - name: Enable logrotate for vault
   template:
-    src: vault_logrotate.j2
+    src: "{{ vault_logrotate_template }}"
     dest: /etc/logrotate.d/vault
     owner: root
     group: root
@@ -91,7 +91,7 @@
 
 - name: Listener configuration
   template:
-    src: vault_listener.hcl.j2
+    src: "{{ vault_listener_template }}"
     dest: "{{ vault_main_config }}"
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
@@ -101,7 +101,7 @@
 
 - name: BSD init script
   template:
-    src: vault_bsdinit.j2
+    src: "{{ vault_bsdinit_template }}"
     dest: /etc/rc.d/vault
     owner: root
     group: wheel
@@ -110,7 +110,7 @@
 
 - name: SYSV init script
   template:
-    src: vault_sysvinit.j2
+    src: "{{ vault_sysvinit_template }}"
     dest: /etc/init.d/vault
     owner: root
     group: root
@@ -123,7 +123,7 @@
 
 - name: Debian init script
   template:
-    src: vault_debian.init.j2
+    src: "{{ vault_debian_init_template }}"
     dest: /etc/init.d/vault
     owner: root
     group: root
@@ -136,7 +136,7 @@
 
 - name: systemd unit
   template:
-    src: vault_systemd.service.j2
+    src: "{{ vault_systemd_template }}"
     dest: /lib/systemd/system/vault.service
     owner: root
     group: root


### PR DESCRIPTION
This commit sets all the templates referenced in the tasks/main.yml as
variables so that they can be overriden by the user, without needing to
update the roles directory.

Re-solves #2