### PR TITLE
chore: set `AmbientCapabilities` in the vault systemd service configuration

### DIFF
--- a/templates/vault_systemd.service.j2
+++ b/templates/vault_systemd.service.j2
@@ -24,6 +24,7 @@ ProtectHome=read-only
 PrivateTmp=yes
 PrivateDevices=yes
 SecureBits=keep-caps
+AmbientCapabilities=CAP_IPC_LOCK
 Capabilities=CAP_IPC_LOCK+ep
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes


### PR DESCRIPTION
Hi!

I encountered the following error after deploying vault on a fresh Debian Stretch machine.

```
Oct 22 14:00:47 nod01 systemd[29151]: vault.service: Failed at step SECUREBITS spawning /usr/local/bin/vault: Operation not permitted
Oct 22 14:00:47 nod01 systemd[1]: vault.service: Main process exited, code=exited, status=213/SECUREBITS
```

After research, The `Capabilities=` unit file setting has been removed and is ignored for backwards compatibility. `AmbientCapabilities=` and `CapabilityBoundingSet=` should be used
instead.

Here is the related changelog : 

https://github.com/systemd/systemd/blob/8f968c7321be09e7a41b29a0d5d2d2c13ee7ded1/NEWS#L1357
