### PR TITLE
Enhanced role for file based storage backend and testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,20 @@ The role defines variables in `defaults/main.yml`:
 - Vault listener configuration template file
 - Default value: *vault_listener.hcl.j2*
 
+### `vault_backend`
+- Which storage backend should be selected, choices are: consul, file and mysql
+- Default value: *consul*
+
 ### `vault_backend_consul`
 
 - Backend consul template filename
-- Default value: `backend_consul.j2`
+- Default value: *backend_consul.j2*
+
+### `vault_backend_file`
+
+- Backend file template filename
+- Default value: *backend_file.j2*
+
 
 ### `vault_cluster_address`
 
@@ -491,6 +501,22 @@ role directory for this to work.
 
 See `examples/README_VAGRANT.md` for details on quick Vagrant deployments
 under VirtualBox for testing, etc.
+
+## example virtualBox playbook
+example playbook for a file based  vault instance.
+
+```
+- hosts: all
+  gather_facts: True
+  become: true
+  vars:
+    vault_backend: file
+    vault_cluster_disable: True
+    vault_log_level: debug
+  roles:
+    - vault
+
+```
 
 ## Vault Enterprise
 

--- a/README.md
+++ b/README.md
@@ -220,17 +220,17 @@ The role defines variables in `defaults/main.yml`:
 
 ### `vault_backend`
 - Which storage backend should be selected, choices are: consul, file and mysql
-- Default value: *consul
+- Default value: *consul*
 
 ### `vault_backend_consul`
 
 - Backend consul template filename
-- Default value: `backend_consul.j2`
+- Default value: *backend_consul.j2*
 
 ### `vault_backend_file`
 
 - Backend file template filename
-- Default value: `backend_file.j2`
+- Default value: *backend_file.j2*
 
 
 ### `vault_cluster_address`
@@ -430,7 +430,7 @@ differences across distributions:
 
 ### `vault_auto_initialize`
 - Used to auto initialize a vault instance, this is mainly used for testing
-- Default value: _false_
+- Default value: *false*
 
 ### `vault_sha256`
 
@@ -507,7 +507,27 @@ role directory for this to work.
 See `examples/README_VAGRANT.md` for details on quick Vagrant deployments
 under VirtualBox for testing, etc.
 
+## example virtualBox playbook
+example playbook for a file based auto intializing single node vault instance.
 
+```
+- hosts: all
+  gather_facts: True
+  become: true
+  vars:
+    vault_user: vault
+    vault_group: vault
+    vault_manage_group: True
+    vault_ui: True
+    vault_iface: eth1
+    vault_backend: file
+    vault_cluster_disable: True
+    vault_log_level: debug
+    vault_auto_initialize: True
+  roles:
+    - vault
+
+```
 
 ## Vault Enterprise
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ The role defines variables in `defaults/main.yml`:
 - OS group name
 - Default value: *bin*
 
-### `vault_group_name`
+### `vault_manage_group`
+- OS group create Should playbook create the group
+- Default value: _false_
 
-- Inventory group name
-- Default value: `vault_instances`
 
 ### `vault_cluster_name`
 
@@ -218,10 +218,20 @@ The role defines variables in `defaults/main.yml`:
 - Vault listener configuration template file
 - Default value: *vault_listener.hcl.j2*
 
+### `vault_backend`
+- Which storage backend should be selected, choices are: consul, file and mysql
+- Default value: *consul
+
 ### `vault_backend_consul`
 
 - Backend consul template filename
 - Default value: `backend_consul.j2`
+
+### `vault_backend_file`
+
+- Backend file template filename
+- Default value: `backend_file.j2`
+
 
 ### `vault_cluster_address`
 
@@ -417,6 +427,11 @@ differences across distributions:
 - Vault package download URL
 - Default value: `"{{ vault_zip_url }}"`
 
+
+### `vault_auto_initialize`
+- Used to auto initialize a vault instance, this is mainly used for testing
+- Default value: _false_
+
 ### `vault_sha256`
 
 - Vault package SHA256 summary
@@ -491,6 +506,8 @@ role directory for this to work.
 
 See `examples/README_VAGRANT.md` for details on quick Vagrant deployments
 under VirtualBox for testing, etc.
+
+
 
 ## Vault Enterprise
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,7 +53,12 @@ vault_port: 8200
 vault_node_name: "{{ inventory_hostname_short }}"
 vault_main_config: "{{ vault_config_path }}/vault_main.hcl"
 vault_listener_template: vault_listener.hcl.j2
+
+#### Vault storage / backend.
+vault_backend: consul
 vault_backend_consul: vault_backend_consul.j2
+vault_backend_file: vault_backend_file.j2
+
 vault_cluster_disable: false
 vault_cluster_address: "{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"
 vault_cluster_addr: "{{ vault_protocol }}://{{ vault_cluster_address }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,10 @@ vault_checksum_file_url: "https://releases.hashicorp.com/vault/{{ vault_version 
 ### Install Method
 vault_install_remotely: false
 
+### Should the system auto initialize the vault
+### Mainly used for testing
+vault_auto_initialize: false
+
 ### Paths
 vault_bin_path: /usr/local/bin
 vault_config_path: /etc/vault.d
@@ -40,7 +44,6 @@ vault_logrotate_freq: 7
 vault_logrotate_template: vault_logrotate.j2
 
 ### Vault settings
-vault_group_name: vault_instances
 vault_cluster_name: dc1
 vault_datacenter: dc1
 vault_log_level: "{{ lookup('env','VAULT_LOG_LEVEL') | default('info', true) }}"
@@ -53,7 +56,12 @@ vault_port: 8200
 vault_node_name: "{{ inventory_hostname_short }}"
 vault_main_config: "{{ vault_config_path }}/vault_main.hcl"
 vault_listener_template: vault_listener.hcl.j2
+
+#### Vault storage / backend.
+vault_backend: consul
 vault_backend_consul: vault_backend_consul.j2
+vault_backend_file: vault_backend_file.j2
+
 vault_cluster_disable: false
 vault_cluster_address: "{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"
 vault_cluster_addr: "{{ vault_protocol }}://{{ vault_cluster_address }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,13 @@
 - name: Include asserts
   include: asserts.yml
 
+- name: "Add Vault Group"
+  group:
+    name: "{{vault_group}}"
+    system: true
+    state: present
+  when: vault_manage_group | bool
+
 - name: "Add Vault user"
   user:
     name: "{{ vault_user }}"
@@ -155,11 +162,59 @@
 - name: Restart Vault if needed
   meta: flush_handlers
 
-# This should succeed regardless of seal state
-- name: Vault API reachable?
+
+- name: Vault API reachable and is it initialized?
   uri:
     validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
-    url: "{{ vault_tls_disable | ternary('http', 'https') }}://{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}:{{ vault_port }}/v1/sys/health"
+    url: "{{ vault_tls_disable | ternary('http', 'https') }}{{':'}}//{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}{{':'}}{{ vault_port }}/v1/sys/init"
+    method: GET
+    # 200 if initialized, unsealed, and active.
+    # See: https://www.vaultproject.io/api/system/health.html
+    status_code: 200
+    body_format: json
+    changed_when: false
+  register: check_initialized_result
+
+
+  # If we have a system under test and we need to auto
+  # initialize it.
+- name: Initialize vault for testing
+  shell: "VAULT_ADDR={{VAULT_ADDR}} vault operator init"
+  register: init_result
+  when: (vault_auto_initialize | bool) and
+        ( check_initialized_result.json.initialized == false)
+
+- debug:
+    msg: "Initialized the vault instance keys are:\n {{ init_result.stdout }}"
+  when: (vault_auto_initialize | bool) and
+        ( check_initialized_result.json.initialized == false) and
+        ( init_result.rc == 0 )
+
+  #
+  # Recheck initialized status
+  # on systems with no auto auto unseal this will be done twice,
+  # but it's a small price to pay to keep the logic simple
+- name: Vault API initialized and sealed?
+  uri:
+    validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
+    url: "{{ vault_tls_disable | ternary('http', 'https') }}{{':'}}//{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}{{':'}}{{ vault_port }}/v1/sys/init"
+    method: GET
+    # 200 if initialized, unsealed, and active.
+    # See: https://www.vaultproject.io/api/system/health.html
+    status_code: 200
+    body_format: json
+    changed_when: false
+  register: verify_initialized_result
+  when: ( check_initialized_result.json.initialized == false)
+
+
+# This should succeed regardless of seal state
+# A 503 return is a sealed status in a single instance condition.
+# BUT it will not work if the vault has never been intialized before.
+- name: Vault health API reachable?
+  uri:
+    validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
+    url: "{{ vault_tls_disable | ternary('http', 'https') }}{{':'}}//{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}{{':'}}{{ vault_port }}/v1/sys/health"
     method: GET
     # 200 if initialized, unsealed, and active.
     # 429 is also OK for HA cluster (means standby + unsealed in HA)
@@ -171,3 +226,10 @@
   until: check_result is succeeded
   delay: 10
   changed_when: false
+  failed_when: check_result.status == -1
+  when: ( verify_initialized_result.json.initialized == true)
+
+- debug:
+    msg: "The vault is sealed but operational {{check_result.msg }}"
+  when: check_result.json.sealed == true
+

--- a/templates/vault_listener.hcl.j2
+++ b/templates/vault_listener.hcl.j2
@@ -28,7 +28,17 @@ listener "tcp" {
   tls_disable = "{{ vault_tls_disable | bool | lower }}"
 }
 
-{% include vault_backend_consul with context %}
+{#
+  Select which backend you want generated and placed
+  in the vault configuration file.
+#}
+{% if vault_backend == 'consul' %}
+  {% include vault_backend_consul with context %}
+{% elif vault_backend == 'file' %}
+  {% include vault_backend_file with context %}
+{% elif vault_backend == 'mysql' %}
+  {% include vault_backend_mysql with context %}
+{% endif %}
 
 {% if vault_ui -%}
   ui = {{ vault_ui | bool | lower }}


### PR DESCRIPTION
Notes on changes:

* Removed unused vault_group_name variable
* Added an option for the playbook to create the os group if it doesn't exist
* Added an option for the playbook to initialize a vault instance, this is mainly for testing.
* Added storage backend for file, mainly used for testing without a consul cluster.
* Updated the vault_listener.hcl.j2 template fale to handle different storage backends, such as consul, file, and mysql
* Changed the end of the playbook check for if the API is reachable.  When using a brand new cluster that has never been initialized the check to see if it's initialized will always work if the API is reachable.  If not initialized the heath endpoint will not respond.
* Added a check to see if the vault has been initialized
* Added ability to initialize the vault and print out the initialization keys to stdout, this is mainly used for testing.
* Changed the API check to check the health endpoint only if the vault has been initialized.
* Changed the url used to reach the vault instance by surrounding the colons in {{':'}} because otherwise the jinja template engine in version 2.7 of ansible barfs on the colon.