### PR TITLE
fix: use AmbientCapabilities only when systemd version is >= 230

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,6 +134,14 @@
     - not ansible_os_family == "FreeBSD"
     - not ansible_os_family == "Solaris"
 
+- name: extract systemd version
+  shell: systemctl --version systemd | head -n 1 | cut -d' ' -f2
+  register: systemd_version
+  when:
+    - ansible_service_mgr == "systemd"
+    - not ansible_os_family == "FreeBSD"
+    - not ansible_os_family == "Solaris"
+
 - name: systemd unit
   template:
     src: "{{ vault_systemd_template }}"
@@ -145,6 +153,7 @@
     - ansible_service_mgr == "systemd"
     - not ansible_os_family == "FreeBSD"
     - not ansible_os_family == "Solaris"
+    - systemd_version is defined
 
 - name: Start Vault
   service:

--- a/templates/vault_systemd.service.j2
+++ b/templates/vault_systemd.service.j2
@@ -25,7 +25,9 @@ PrivateTmp=yes
 PrivateDevices=yes
 SecureBits=keep-caps
 Capabilities=CAP_IPC_LOCK+ep
+{% if systemd_version | version_compare('230', '>=') %}
 AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK
+{% endif %}
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
 ExecStart={{ vault_bin_path }}/vault server -config={{ vault_main_config }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}


### PR DESCRIPTION
Hi,

The `AmbientCapabilities` directive I've introduced to the systemd config in brianshumate/ansible-vault#65 cause a breakage on "old" systemd versions. 
This patch extract version and include `AmbientCapabilities` directive only if version is `>=` to `230`

Sorry for the breakage :-/

close: brianshumate/ansible-vault#67