### PR TITLE
Performance Standby nodes return HTTP code 473

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -174,8 +174,9 @@
     method: GET
     # 200 if initialized, unsealed, and active.
     # 429 is also OK for HA cluster (means standby + unsealed in HA)
+    # 473 if also OK for Performance Standby (Enterprise feature)
     # See: https://www.vaultproject.io/api/system/health.html
-    status_code: "{{ vault_cluster_disable | ternary('200', '200, 429') }}"
+    status_code: "{{ vault_cluster_disable | ternary('200', '200, 429, 473') }}"
     body_format: json
   register: check_result
   retries: 30


### PR DESCRIPTION
Vault Enterprise Performance Standby Nodes HTTP Status Code (473) added as healthy into Vault API reachable?