### PR TITLE
Added support for GCP Cloud KMS Auto-unseal

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,52 @@ The role can configure HSM based instances. Make sure to reference the [HSM supp
 - The slot number to use, specified as a string (e.g. "0"). May also be specified by the VAULT_HSM_SLOT environment variable. This label will only be applied when `vault_softcard_enable` is false (default).
 - Default value: *0*
 
+## Vault GCP Cloud KMS Auto-unseal
+
+This feature enables operators to delegate the unsealing process to Google Key Management System Cloud to ease operations in the event of partial failure and to aid in the creation of new or ephemeral clusters.
+
+This Auto-unseal mechanism is Open Source in Vault 1.0 but would require Enterprise binaries for any earlier version.
+
+### `vault_gkms`
+
+- Set to True to enable Google Cloud KMS Auto-Unseal.
+- Default value: *false*
+
+### `vault_backend_gkms`
+
+- Backend seal template filename
+- Default value: *vault_backend_gkms.j2*
+
+### `vault_gkms_project`
+
+- GCP Project where the key reside.
+- Default value: *''*
+
+### `vault_gkms_credentials_src_file`
+
+- User-specified source directory for GCP Credential on Ansible control node.
+- Default value: *''*
+
+### `vault_gkms_credentials`
+
+- Path to GCP credential on Vault server.
+- Default value: `/home/vault/vault-kms.json`
+
+### `vault_gkms_region`
+
+- GCP Region where the key reside.
+- Default value: *global*
+
+### `vault_gkms_key_ring`
+
+- The id of the Google Cloud Platform KeyRing to which the key shall belong.
+- Default value: *vault*
+
+### `vault_gkms_crypto_key`
+
+- The CryptoKey's name. A CryptoKey's name must be unique within a location and match the regular expression [a-zA-Z0-9_-]{1,63}
+- Default value: *vault_key*
+
 ## License
 
 BSD

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,3 +123,13 @@ vault_seal_slot: 0
 vault_softcard_enable: false
 vault_telemetry_enabled: false
 
+## Vault Google KMS - auto unseal
+
+vault_gkms: false
+vault_backend_gkms: vault_backend_gkms.j2
+vault_gkms_project: ''
+vault_gkms_credentials_src_file: ''
+vault_gkms_credentials: '/home/vault/vault-kms.json'
+vault_gkms_region: 'global'
+vault_gkms_key_ring: 'vault'
+vault_gkms_crypto_key: 'vault_key'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,6 +89,15 @@
   include: ../tasks/tls.yml
   when: vault_tls_disable == 0
 
+- name: "Copy over GCP Credentials for Auto Unseal"
+  copy:
+    src: "{{ vault_gkms_credentials_src_file }}"
+    dest: "{{ vault_gkms_credentials }}"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+    mode: "0600"
+  when: vault_gkms | bool
+
 - name: Listener configuration
   template:
     src: "{{ vault_listener_template }}"
@@ -174,7 +183,7 @@
     method: GET
     # 200 if initialized, unsealed, and active.
     # 429 is also OK for HA cluster (means standby + unsealed in HA)
-    # 473 if also OK for Performance Standby (Enterprise feature)
+    # 473 is also OK for Performance Standby (Enterprise feature)
     # See: https://www.vaultproject.io/api/system/health.html
     status_code: "{{ vault_cluster_disable | ternary('200', '200, 429, 473') }}"
     body_format: json

--- a/templates/vault_backend_gkms.j2
+++ b/templates/vault_backend_gkms.j2
@@ -1,0 +1,7 @@
+seal "gcpckms" {
+  credentials = "{{ vault_gkms_credentials }}"
+  project     = "{{ vault_gkms_project }}"
+  region      = "{{ vault_gkms_region }}"
+  key_ring    = "{{ vault_gkms_key_ring }}"
+  crypto_key  = "{{ vault_gkms_crypto_key }}"
+}

--- a/templates/vault_listener.hcl.j2
+++ b/templates/vault_listener.hcl.j2
@@ -38,6 +38,10 @@ listener "tcp" {
   {% include vault_backend_seal with context %}
 {% endif -%}
 
+{% if vault_gkms | bool -%}
+  {% include vault_backend_gkms with context %}
+{% endif -%}
+
 {% if vault_telemetry_enabled | bool -%}
 telemetry {
   {% if vault_statsite_address is defined %}


### PR DESCRIPTION
Vault 1.0 Open Source is now available and comes with support for Auto Unseal on major clouds by leveraging their Key Management System (Amazon KMS, Azure Key Vault, Google Cloud KMS, AliCloud KMS).

Auto Unseal enables operators to delegate the unsealing process to trusted cloud providers to ease operations.

This pull request add support for Google Cloud KMS Auto-unseal feature. It has been successfully tested on Google Cloud Plaform. Test has also be ran with this feature off to make sure it doesn't break installation which doesn't need support for Auto-unseal.

The minimum required variable to setup for testing are:

- vault_gkms: true
- vault_gkms_project: '<GCP_PROJECT_NAME>'
- vault_gkms_credentials_src_file: '<GCP_CREDENTIAL_PATH>'

Ansible will then configure Vault to use

- a key named *vault_key*
- in the *vault* keyring
- in the *global* region

All these variables can be updated in your `site.yml` file, consult `README.md` for further details.

Thanks,
planetrobbie.