### PR TITLE
VAULT_ADDR and VAULT_CACERT export in ~/.bashrc

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ vault_config_path: /etc/vault.d
 vault_data_path: /var/vault
 vault_log_path: /var/log/vault
 vault_run_path: /var/run/vault
+vault_home: /home
 
 ### System user and group
 vault_manage_user: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -175,6 +175,21 @@
 - name: Restart Vault if needed
   meta: flush_handlers
 
+- name: Insert http(s) export in dotfile
+  lineinfile: 
+    path: "{{ vault_home }}/{{ ansible_ssh_user }}/.bashrc"
+    line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ inventory_hostname }}:{{ vault_port }}'"
+  when:
+    - ansible_os_family != 'Windows'
+
+- name: Insert CA cert export in dotfile
+  lineinfile: 
+    path: "{{ vault_home }}/{{ ansible_ssh_user }}/.bashrc"
+    line: "export VAULT_CACERT={{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+  when:
+    - not vault_tls_disable | bool
+    - ansible_os_family != 'Windows'
+
 # This should succeed regardless of seal state
 - name: Vault API reachable?
   uri:


### PR DESCRIPTION
When running Vault CLI from the Vault instances themselves, connection happens by default on 127.0.0.1 when environment variables aren't set. So this will fail in most cases, vault may not listen on localhost.

So this pull request inject for UNIX based platforms following environment variables in `~/.bashrc` to make sure Vault CLI runs well locally.

- `export VAULT_ADDR='http(s)://{{inventory_hostname}}:{{vault_port}}'`
- `export VAULT_CACERT=/etc/vault/tls/ca.crt`

The second one will only be added only if TLS is not disabled and is necessary to avoid the boring `-tls-skip-verify` argument when running vault CLI when certificates can't be verified.

It allows to verify the TLS Certificate using the `ca.crt` file that has been pushed by Ansible. Ansible Inventory hostname should then be using nodes FQDN to make sure this TLS Certificate validation can happen correctly. But if that's not the case it's always possible to use `-tls-skip-verify` or by setting up `VAULT_SKIP_VERIFY=true` in `~/.bashrc`

Thanks,
planetrobbie.