### PR TITLE
Fix install failure when .bashrc does not exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,6 +179,7 @@
   lineinfile: 
     path: "{{ vault_home }}/{{ ansible_ssh_user }}/.bashrc"
     line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ inventory_hostname }}:{{ vault_port }}'"
+    create: yes
   when:
     - ansible_os_family != 'Windows'
 
@@ -186,6 +187,7 @@
   lineinfile: 
     path: "{{ vault_home }}/{{ ansible_ssh_user }}/.bashrc"
     line: "export VAULT_CACERT={{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+    create: yes
   when:
     - not vault_tls_disable | bool
     - ansible_os_family != 'Windows'


### PR DESCRIPTION
All users do not have a .bashrc. 
[PR76](https://github.com/brianshumate/ansible-vault/pull/76) adds lines to bashrc but causes install failure if the file does not exist.

Solution: allow bashrc file creation if it does not exist.
