### PR TITLE
Add vault_bin_path to the PATH

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,8 @@
 
 - name: Check Vault installation
   command: which vault
+  environment:
+    PATH: "{{ vault_bin_path }}:{{ ansible_env.PATH }}"
   register: vault_installation
   changed_when: false
   ignore_errors: true


### PR DESCRIPTION
The vault_bin_path might not be included in the search path
for the user executing Ansible.
This will cause the install to be done over and over again.

At least on systems running RHEL the, default, /usr/local/bin
vault_bin_path is not included in the PATH of root