### PR TITLE
Ensure systemd is reloaded on unit changes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -161,11 +161,22 @@
     owner: root
     group: root
     mode: "0644"
+  register: systemd_unit
   when:
     - ansible_service_mgr == "systemd"
     - not ansible_os_family == "FreeBSD"
     - not ansible_os_family == "Solaris"
     - systemd_version is defined
+
+- name: reload systemd
+  systemd:
+    daemon-reload: true
+  when:
+    - ansible_service_mgr == "systemd"
+    - not ansible_os_family == "FreeBSD"
+    - not ansible_os_family == "Solaris"
+    - systemd_version is defined
+    - systemd_unit is changed
 
 - name: Start Vault
   service:


### PR DESCRIPTION
If systemd doesn't get reloaded it will issue a warning and use the
old service definition