### PR TITLE
Revert long line syntax change

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,9 +179,7 @@
 - name: Insert http(s) export in dotfile
   lineinfile:
     path: "{{ vault_home }}/{{ ansible_ssh_user }}/.bashrc"
-    line: >-
-      "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}"
-      "://{{ inventory_hostname }}:{{ vault_port }}'"
+    line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ inventory_hostname }}:{{ vault_port }}'"
     create: true
   when:
     - ansible_os_family != 'Windows'


### PR DESCRIPTION
Using the folded block scalar causes a space to be added between the scheme and the colon

This results in a line looking like this:
```
"export VAULT_ADDR='http" "://localhost.local:8200'"
```
Causing the below error when sourcing .bashrc
```
-bash: export VAULT_ADDR='http: command not found
```