### PR TITLE
Vault health check

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,8 +60,6 @@ vault_node_name: "{{ inventory_hostname_short }}"
 vault_main_config: "{{ vault_config_path }}/vault_main.hcl"
 vault_listener_template: vault_listener.hcl.j2
 
-vault_health_check: true
-
 # ---------------------------------------------------------------------------
 # Storage backend
 # ---------------------------------------------------------------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -207,7 +207,7 @@
     # 501 if not initialized
     # 503 if sealed
     # See: https://www.vaultproject.io/api/system/health.html
-    status_code: "{{ vault_cluster_disable | ternary('200', '200, 429, 473, 501, 503') }}"
+    status_code: "{{ vault_cluster_disable | ternary('200, 503', '200, 429, 473, 501, 503') }}"
     body_format: json
   register: check_result
   retries: 30


### PR DESCRIPTION
- Ensure the health check also succeeds when the vault is sealed for a standalone node
- Remove obsolete `vault_health_check` variable