### PR TITLE
Remove if construct for vault_log_level

### DIFF
--- a/templates/vault_service_debian_init.j2
+++ b/templates/vault_service_debian_init.j2
@@ -14,7 +14,7 @@ DESC="Vault secret management tool"
 NAME=vault
 DAEMON="{{ vault_bin_path }}/$NAME"
 PIDFILE=/var/run/$NAME/$NAME.pid
-DAEMON_ARGS="server -config={{ vault_main_config }} {% if vault_log_level | bool %}-log-level={{ vault_log_level | lower }}{% endif %}"
+DAEMON_ARGS="server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }}"
 USER={{ vault_user }}
 SCRIPTNAME=/etc/init.d/$NAME
 

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -30,8 +30,7 @@ AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK
 {% endif %}
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
-ExecStart={{ vault_bin_path }}/vault server -config={{ vault_main_config }} {% if vault_log_level | bool %}-log-level={{ vault_log_level | lower }}
-{% endif %}
+ExecStart={{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }}
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGINT


### PR DESCRIPTION
Using the default filter in defaults/main.yml will cause this variable to always have a value.

The bool filter would always return false unless somebody sets the
vault_log_level to true/yes/.. removing the `-log-level` statement from the result altogether.

Example:
```
ExecStart=/usr/local/bin/vault server -config=/etc/vault/vault_main.hcl ExecReload=/bin/kill --signal HUP $MAINPID
```