### PR TITLE
Add plugin path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ The role defines variables in `defaults/main.yml`:
 - Configuration file path
 - Default value: `/etc/vault.d`
 
+### `vault_plugin_path`
+
+- Path from where plugins can be loaded
+- Default value: `/usr/local/lib/vault/plugins`
+
 ### `vault_data_path`
 
 - Data path

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ vault_install_remotely: false
 # Paths
 vault_bin_path: /usr/local/bin
 vault_config_path: /etc/vault.d
+vault_plugin_path: /usr/local/lib/vault/plugins
 vault_data_path: /var/vault
 vault_log_path: /var/log/vault
 vault_run_path: /var/run/vault

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,6 +80,7 @@
     group: "{{ vault_group }}"
   with_items:
     - "{{ vault_config_path }}"
+    - "{{ vault_plugin_path }}"
     - "{{ vault_data_path }}"
     - "{{ vault_log_path }}"
     - "{{ vault_run_path }}"

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -6,6 +6,8 @@ disable_clustering = "{{ vault_cluster_disable }}"
 cluster_addr = "{{ vault_cluster_addr }}"
 api_addr = "{{ vault_api_addr }}"
 
+plugin_directory = "{{ vault_plugin_path }}"
+
 listener "tcp" {
   address = "{{ vault_address }}:{{ vault_port }}"
   cluster_address = "{{ vault_cluster_address }}"


### PR DESCRIPTION
I need the ability to load custom plugins in my vault instance, added a new variable `vault_plugin_path` and proper vault configuration parameter to enable plugins usage.