### PR TITLE
set vault_home default value to /home/{{ansible_user}}

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,7 +29,7 @@ vault_config_path: /etc/vault.d
 vault_data_path: /var/vault
 vault_log_path: /var/log/vault
 vault_run_path: /var/run/vault
-vault_home: /home
+vault_home: "/home/{{ ansible_user }}"
 
 # System user and group
 vault_manage_user: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -203,7 +203,7 @@
 
 - name: Insert http(s) export in dotfile
   lineinfile:
-    path: "{{ vault_home }}/{{ ansible_ssh_user }}/.bashrc"
+    path: "{{ vault_home }}/.bashrc"
     line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ inventory_hostname }}:{{ vault_port }}'"
     create: true
   when:
@@ -211,7 +211,7 @@
 
 - name: Insert CA cert export in dotfile
   lineinfile:
-    path: "{{ vault_home }}/{{ ansible_ssh_user }}/.bashrc"
+    path: "{{ vault_home }}/.bashrc"
     line: "export VAULT_CACERT={{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
     create: true
   when:


### PR DESCRIPTION
In order to override the full `vault_home` path without changing the ssh user