### PR TITLE
Fix: #99 - Force /bin/bash usage on Get Vault package checksum (local)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fixup Get installed Vault version for multiline/quotes
 - Update vault_home value (thanks @xeivieni)
 - Add plugin_dir configuration (thanks @vmwiz)
+- Fix: Force `/bin/bash` on Get Vault package checksum (local) (thanks @fleu42)
 
 ## v2.1.9
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -40,7 +40,8 @@
 - name: Get Vault package checksum (local)
   shell: |
     set -o pipefail
-    grep "{{ vault_pkg }}" "{{ role_path }}/files/{{ vault_shasums }}" | awk '{print $1}'
+    grep "{{ vault_pkg }}" "{{ role_path }}/files/{{ vault_shasums }}" | \
+    awk '{print $1}'
   args:
     executable: /bin/bash
   become: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -41,6 +41,8 @@
   shell: |
     set -o pipefail
     grep "{{ vault_pkg }}" "{{ role_path }}/files/{{ vault_shasums }}" | awk '{print $1}'
+  args:
+    executable: /bin/bash
   become: false
   run_once: true
   register: vault_sha256


### PR DESCRIPTION
As stated in the issue:

`set -o pipefail` is a bash option so the task `Get Vault package checksum (local)` fails if sh is the default local shell.

```
TASK [ansible-vault : Get Vault package checksum (local)] **********************************************************************************************************************************************************
fatal: [vault-01.xxxx -> 127.0.0.1]: FAILED! => {
    "changed": true,
    "cmd": "set -o pipefail\n grep \"vault_1.1.2_linux_amd64.zip\" \"/home/fleu42/Code/ansible/roles/ansible-vault/files/vault_1.1.2_SHA256SUMS\" | awk '{print $1}'",
    "delta": "0:00:00.002455",
    "end": "2019-05-21 16:51:43.528522",
    "rc": 2,
    "start": "2019-05-21 16:51:43.526067"
}

STDERR:

/bin/sh: 1: set: Illegal option -o pipefail


MSG:

non-zero return code
```

I use:

```
$ python --version                                                                                                                                                  
Python 3.6.7
```

and 

```
$ ansible --version                                                                                                                                                 
ansible 2.7.10                                                                                                                                                                                                     
  config file = /home/fleu42/Code/ansible/playbooks/ansible.cfg
  configured module search path = ['/home/fleu42/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fleu42/Code/ansible/playbooks/ansible/lib/python3.6/site-packages/ansible
  executable location = /home/fleu42/Code/ansible/playbooks/ansible/bin/ansible
  python version = 3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
```

with my change, the task succeeds:

```
TASK [ansible-vault : Get Vault package checksum (local)] **********************************************************************************************************************************************************
changed: [vault-01.somedomain.local -> 127.0.0.1]
```