### PR TITLE
Fix template line break

### DIFF
--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -44,7 +44,7 @@ listener "tcp" {
 {# We don't currentlty have this backend template available! #}
 {% elif vault_backend == 'mysql' -%}
   {% include vault_backend_mysql with context -%}
-{% endif -%}
+{% endif %}
 
 {% if vault_ui -%}
 ui = {{ vault_ui | bool | lower }}


### PR DESCRIPTION
Newline was missing before "ui":

```
storage "file" {
  path = "/var/vault"
}ui = true
```