### PR TITLE
Add support for backend tls configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## v2.2.2 (UNRELEASED)
+## v2.3.0 (UNRELEASED)
 
+- Add support for backend tls configuration
+- Update documentation
 - Remove nonfunctional vault_node_name configuration
 
 ## v2.2.1

--- a/README.md
+++ b/README.md
@@ -150,6 +150,31 @@ The role defines variables in `defaults/main.yml`:
 - Which storage backend should be selected, choices are: consul, etcd, file, and mysql
 - Default value: consul
 
+### `vault_backend_tls_src_files`
+
+- User-specified source directory for TLS files for storage communication
+- {{ vault_tls_src_files }}
+
+### `vault_backend_tls_config_path`
+
+- Path to directory containing backend tls config files
+- {{ vault_tls_config_path }}
+
+### `vault_backend_tls_cert_file`
+
+- Specifies the path to the certificate for backend communication (if supported).
+- {{ vault_tls_cert_file }}
+
+### `vault_backend_tls_key_file`
+
+- Specifies the path to the private key for backend communication (if supported).
+- {{ vault_tls_key_file }}
+
+### `vault_backend_tls_ca_file`
+
+- CA certificate used for backend communication (if supported). This defaults to system bundle if not specified.
+- {{ vault_tls_ca_file }}
+
 ### Consul Storage Backend
 
 ### `vault_backend_consul`
@@ -329,7 +354,7 @@ The role defines variables in `defaults/main.yml`:
 
 ### `vault_tls_gossip`
 
-- Enable TLS Gossip to Consul Backend
+- Enable TLS Gossip to storage (if supported)
 - Default value: 0
 
 ### `vault_tls_src_files`
@@ -387,6 +412,11 @@ The role defines variables in `defaults/main.yml`:
 
 - [Disable requesting for client certificates](https://www.vaultproject.io/docs/configuration/listener/tcp.html#tls_disable_client_certs)
 - Default value: false
+
+### `vault_tls_copy_keys`
+
+- Copy TLS files from src to dest
+- Default value: true
 
 ### `vault_tls_files_remote_src`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,6 +75,13 @@ vault_api_addr: "{{ vault_protocol }}://{{ vault_redirect_address | default(host
 vault_max_lease_ttl: "768h"
 vault_default_lease_ttl: "768h"
 
+# Storage tls settings
+vault_backend_tls_src_files: "{{ vault_tls_src_files }}"
+vault_backend_tls_config_path: "{{ vault_tls_config_path }}"
+vault_backend_tls_cert_file: "{{ vault_tls_cert_file }}"
+vault_backend_tls_key_file: "{{ vault_tls_key_file }}"
+vault_backend_tls_ca_file: "{{ vault_tls_ca_file }}"
+
 # Consul storage settings
 vault_consul: 127.0.0.1:8500
 vault_consul_path: vault

--- a/tasks/backend_tls.yml
+++ b/tasks/backend_tls.yml
@@ -1,0 +1,33 @@
+---
+# File: tasks/backend_tls.yml - Backend TLS tasks for Vault
+
+- name: Create backend TLS directory
+  become: true
+  file:
+    dest: "{{ item }}"
+    state: directory
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+  with_items:
+    - "{{ vault_backend_tls_config_path }}"
+
+- name: Vault backend SSL Certificate and Key
+  become: true
+  copy:
+    remote_src: "{{ vault_tls_files_remote_src }}"
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+    mode: "{{ item.mode }}"
+  with_items:
+    - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_cert_file }}"
+      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+      mode: "0644"
+    - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_key_file }}"
+      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
+      mode: "0600"
+    - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_ca_file }}"
+      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
+      mode: "0644"
+  when: vault_tls_copy_keys | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,7 +98,11 @@
 
 - name: TLS configuration
   include: ../tasks/tls.yml
-  when: vault_tls_disable == 0 or vault_tls_gossip == 1
+  when: vault_tls_disable == 0
+
+- name: Backend storage TLS configuration
+  include: ../tasks/backend_tls.yml
+  when: vault_tls_gossip == 1
 
 - name: "Copy over GCP Credentials for Auto Unseal"
   copy:

--- a/templates/vault_backend_consul.j2
+++ b/templates/vault_backend_consul.j2
@@ -7,8 +7,8 @@ backend "consul" {
   {% endif %}
   scheme = "{{ vault_consul_scheme }}"
   {% if vault_tls_gossip | bool %}
-  tls_cert_file = "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
-  tls_key_file = "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
-  tls_ca_file="{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+  tls_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+  tls_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
+  tls_ca_file="{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
   {% endif %}
 }

--- a/templates/vault_backend_etcd.j2
+++ b/templates/vault_backend_etcd.j2
@@ -15,9 +15,9 @@ backend "etcd" {
   password = "{{ vault_etcd_password }}"
   {% endif -%}
   {% if vault_tls_gossip | bool -%}
-  tls_cert_file = "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
-  tls_key_file = "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
-  tls_ca_file="{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+  tls_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+  tls_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
+  tls_ca_file="{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
   {% endif -%}
 }
 


### PR DESCRIPTION
This pull request adds variables for setting backend tls options. Previously, they were hardcoded to the listener tls options. The new backend options default to the listener options. 