### PR TITLE
Fix Vault installation check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Check Vault installation
-  command: command vault
+  shell: command -v vault
   environment:
     PATH: "{{ vault_bin_path }}:{{ ansible_env.PATH }}"
   register: vault_installation


### PR DESCRIPTION
Command require -v option to output the binary path.
Also, command seems to require a shell to work.