### PR TITLE
Vault API status check.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,10 +244,20 @@
     # 501 if not initialized
     # 503 if sealed
     # See: https://www.vaultproject.io/api/system/health.html
-    status_code: "{{ vault_cluster_disable | ternary('200, 503', '200, 429, 473, 501, 503') }}"
+    status_code: 200, 503, 200, 429, 473, 501, 503
     body_format: json
   register: check_result
-  retries: 30
+  retries: 6
   until: check_result is succeeded
   delay: 10
   changed_when: false
+  tags:
+    - check_vault
+
+- name: Vault status
+  debug:
+    msg: "Vault is {{ item.value }}"
+  loop: "{{ lookup('dict', vault_http_status) }}"
+  when: "'{{ check_result.status }}' in item.key"
+  tags:
+    - check_vault


### PR DESCRIPTION
```
#This should succeed regardless of seal state
- name: Vault API reachable?
```

I changed it so it succeeds and display a message of the status.