### PR TITLE
Add missing task to add vault group if enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ The role defines variables in `defaults/main.yml`:
 - OS group name
 - Default value: bin
 
+### `vault_manage_group`
+
+- Should this role manage the vault group?
+- Default value: false
+
 ### `vault_group_name`
 
 - Inventory group name

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,14 @@
 - name: Include asserts
   include: asserts.yml
 
-- name: "Add Vault user"
+- name: Add Vault group
+  become: true
+  group:
+    name: "{{ vault_group }}"
+    state: present
+  when: vault_manage_group | bool
+
+- name: Add Vault user
   become: true
   user:
     name: "{{ vault_user }}"


### PR DESCRIPTION
This PR adds the missing task to create the `vault_group` if `vault_manage_group` is set to true. The variable was already present in the defaults but the corresponding task was missing.

The functionality is therefore aligned with the `brianshumate.consul` role. :)