### PR TITLE
Set tags vault_check to vault_status debug task 

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -265,3 +265,5 @@
 - name: Vault status
   debug:
     msg: "Vault is {{ vault_http_status[check_result.status|string] }}"
+  tags:
+    - check_vault


### PR DESCRIPTION
If you skip vault health check Vault status will fail since check_result.status is not available
