### PR TITLE
Add the possibility to enable vault commands to localhost

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,7 @@ vault_ui: "{{ lookup('env', 'VAULT_UI') | default(true, true) }}"
 vault_port: 8200
 vault_main_config: "{{ vault_config_path }}/vault_main.hcl"
 vault_main_configuration_template: vault_main_configuration.hcl.j2
+vault_listener_localhost_enable: False
 
 # ---------------------------------------------------------------------------
 # Storage backend

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -30,6 +30,14 @@ listener "tcp" {
   tls_disable = "{{ vault_tls_disable | bool | lower }}"
 }
 
+{% if (vault_listener_localhost_enable | bool) -%}
+listener "tcp" {
+  address = "127.0.0.1:8200"
+  cluster_address = "127.0.0.1:8201"
+  tls_disable = "true"
+}
+{% endif -%}
+
 {#
   Select which storage backend you want generated and placed
   in the vault configuration file.


### PR DESCRIPTION
After looking to the error "Error initializing: Put http://127.0.0.1:8200/v1/sys/init: dial tcp 127.0.0.1:8200: connect: connection refused" I created a listener for localhost that could be enabled by a variable.

The default behavior is like before, without a listener for localhost.