### PR TITLE
Added user_groups variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ The role defines variables in `defaults/main.yml`:
 - OS group name
 - Default value: bin
 
+### `vault_groups`
+
+- OS additional groups as in ansibles user module
+- Default value: null
+
 ### `vault_manage_group`
 
 - Should this role manage the vault group?

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ vault_manage_user: true
 vault_user: vault
 vault_manage_group: false
 vault_group: bin
+vault_groups: null
 
 # Logging
 vault_enable_logrotate: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
     name: "{{ vault_user }}"
     comment: "Vault user"
     group: "{{ vault_group }}"
+    groups: "{{ vault_groups }}"
     system: true
   when: vault_manage_user | bool
 


### PR DESCRIPTION
Added the possibility to supply additional groups to the vault systems user.

Enables easier access to common used tls secrets without using the same group or user on all sharing services.