### PR TITLE
Add optional proxy variables for the server to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- Add support for proxy configuration
+
 ## v2.5.3
 - Add Prometheus telemetry support (thanks @bbayszczak)
 - Add tag check_vault to to Vault status debug task (thanks @NorthFuture)

--- a/README.md
+++ b/README.md
@@ -570,6 +570,21 @@ available starting at Vault version 1.4.
 - Vault main configuration template file
 - Default value: *vault_main_configuration.hcl.j2*
 
+### `vault_http_proxy`
+
+- Address to be used as the proxy for HTTP and HTTPS requests unless overridden by `vault_https_proxy` or `vault_no_proxy`
+- Default value: `""`
+
+### `vault_https_proxy`
+
+- Address to be used as the proxy for HTTPS requests unless overridden by `vault_no_proxy`
+- Default value: `""`
+
+### `vault_no_proxy`
+
+- Comma separated values which specify hosts that should be exluded from proxying.  Follows [golang conventions](https://godoc.org/golang.org/x/net/http/httpproxy)
+- Default value: `""`
+
 ### `vault_cluster_address`
 
 - Address to bind to for cluster server-to-server requests

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,9 @@ vault_ui: "{{ lookup('env', 'VAULT_UI') | default(true, true) }}"
 vault_port: 8200
 vault_main_config: "{{ vault_config_path }}/vault_main.hcl"
 vault_main_configuration_template: vault_main_configuration.hcl.j2
+vault_http_proxy: ""
+vault_https_proxy: ""
+vault_no_proxy: ""
 
 # ---------------------------------------------------------------------------
 # Storage backend

--- a/templates/vault_service_bsd_init.j2
+++ b/templates/vault_service_bsd_init.j2
@@ -20,6 +20,15 @@ stop_cmd=vault_stop
 
 vault_start() {
     echo "Starting ${name}."
+    {% if vault_http_proxy -%}
+    export HTTP_PROXY={{ vault_http_proxy }}
+    {% endif -%}
+    {% if vault_https_proxy -%}
+    export HTTPS_PROXY={{ vault_https_proxy }}
+    {% endif -%}
+    {% if vault_no_proxy -%}
+    export NO_PROXY={{ vault_no_proxy }}
+    {% endif -%}
     for user in ${vault_users}; do
         mkdir /var/run/vault
         chown -R "{{ vault_user }}:{{ vault_group }}" /var/run/vault/

--- a/templates/vault_service_debian_init.j2
+++ b/templates/vault_service_debian_init.j2
@@ -32,6 +32,15 @@ mkrundir() {
 }
 
 do_start() {
+    {% if vault_http_proxy -%}
+    export HTTP_PROXY={{ vault_http_proxy }}
+    {% endif -%}
+    {% if vault_https_proxy -%}
+    export HTTPS_PROXY={{ vault_https_proxy }}
+    {% endif -%}
+    {% if vault_no_proxy -%}
+    export NO_PROXY={{ vault_no_proxy }}
+    {% endif -%}
     mkrundir
     start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile --test > /dev/null \
         || return 1

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -30,6 +30,15 @@ AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK
 {% endif %}
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
+{% if vault_http_proxy -%}
+Environment=HTTP_PROXY={{ vault_http_proxy }}
+{% endif -%}
+{% if vault_https_proxy -%}
+Environment=HTTPS_PROXY={{ vault_https_proxy }}
+{% endif -%}
+{% if vault_no_proxy -%}
+Environment=NO_PROXY={{ vault_no_proxy }}
+{% endif -%}
 ExecStart=/bin/sh -c '{{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process

--- a/templates/vault_sysvinit.j2
+++ b/templates/vault_sysvinit.j2
@@ -37,6 +37,15 @@ mkpidfile() {
 
 start() {
         echo -n "Starting vault: "
+        {% if vault_http_proxy -%}
+        export HTTP_PROXY={{ vault_http_proxy }}
+        {% endif -%}
+        {% if vault_https_proxy -%}
+        export HTTPS_PROXY={{ vault_https_proxy }}
+        {% endif -%}
+        {% if vault_no_proxy -%}
+        export NO_PROXY={{ vault_no_proxy }}
+        {% endif -%}
         mkrundir
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user={{ vault_user }} \


### PR DESCRIPTION
This PR aims to allow the user to specify a proxy configuration which gets put into the vault server's service definition.  These are all optional and by default there are no environment variables set.