### PR TITLE
Revert the use of the bool filter in the azurekeyvault seal template

### DIFF
--- a/templates/vault_seal_azurekeyvault.j2
+++ b/templates/vault_seal_azurekeyvault.j2
@@ -1,15 +1,15 @@
 seal "azurekeyvault" {
   tenant_id     = "{{ vault_azurekeyvault_tenant_id }}"
-{% if vault_azurekeyvault_client_id | bool %}
+{% if vault_azurekeyvault_client_id is defined -%}
   client_id     = "{{ vault_azurekeyvault_client_id }}"
-{% endif %}
-{% if vault_azurekeyvault_client_secret | bool %}
+{% endif -%}
+{% if vault_azurekeyvault_client_secret is defined -%}
   client_secret = "{{ vault_azurekeyvault_client_secret }}"
-{% endif %}
-{% if vault_azurekeyvault_vault_name | bool %}
+{% endif -%}
+{% if vault_azurekeyvault_vault_name is defined -%}
   vault_name    = "{{ vault_azurekeyvault_vault_name }}"
-{% endif %}
-{% if vault_azurekeyvault_key_name | bool %}
+{% endif -%}
+{% if vault_azurekeyvault_key_name is defined -%}
   key_name      = "{{ vault_azurekeyvault_key_name }}"
-{% endif %}
+{% endif -%}
 }


### PR DESCRIPTION
This PR is meant to close #158 and reverts the changes made to the azurekeyvault template in commit [a833b3b](https://github.com/ansible-community/ansible-vault/commit/a833b3bd2920ac6a35bf2b2ab3782fe7a150ee6d#diff-f406f656f54568277252abdb2c474e94)