### PR TITLE
Recursively set TLS permissions

### DIFF
--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -4,12 +4,11 @@
 - name: Create TLS directory
   become: true
   file:
-    dest: "{{ item }}"
+    dest: "{{ vault_tls_config_path }}"
     state: directory
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
-  with_items:
-    - "{{ vault_tls_config_path }}"
+    recurse: yes
 
 - name: Vault SSL Certificate and Key
   become: true

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -8,7 +8,6 @@
     state: directory
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
-    mode: "u=rwX,g=rX,o=rX"
     recurse: yes
 
 - name: Vault SSL Certificate and Key

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -8,7 +8,7 @@
     state: directory
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
-    mode: "0755"
+    mode: "u=rwX,g=rX,o=rX"
     recurse: yes
 
 - name: Vault SSL Certificate and Key

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -8,6 +8,7 @@
     state: directory
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
+    mode: "0755"
     recurse: yes
 
 - name: Vault SSL Certificate and Key


### PR DESCRIPTION
When `vault_tls_config_path` already exists and `vault_tls_copy_keys` is set to `false`, only the certificates root folder (`vault_tls_config_path`) get the correct permission while the certificates inside aren't touched.