### PR TITLE
feat: add vault log to file with vault_enable_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The role defines variables in `defaults/main.yml`:
 
 ### `vault_log_path`
 
-- Log path - (not yet implemented)
+- Log path
 - Default value: `/var/log/vault`
 
 ### `vault_run_path`
@@ -775,6 +775,11 @@ differences across distributions:
 
 - Vault package SHA256 summary
 - Default value: SHA256 summary
+
+### `vault_enable_log`
+
+- Enable log to `vault_log_path`
+- Default value: false
 
 ### `vault_enable_logrotate`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,9 +40,11 @@ vault_group: bin
 vault_groups: null
 
 # Logging
+vault_enable_log: false
 vault_enable_logrotate: false
 vault_logrotate_freq: 7
 vault_logrotate_template: vault_logrotate.j2
+vault_exec_output: ''
 
 # ---------------------------------------------------------------------------
 # Vault variables

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,6 +138,10 @@
     mode: "0400"
   notify: Restart vault
 
+- name: "Set Exec output to log path when enabled log"
+  set_fact:
+    vault_exec_output: "2>&1 >> {{ vault_log_path }}/vault.log"
+  when: vault_enable_log
 
 - name: BSD init script
   template:

--- a/templates/vault_service_bsd_init.j2
+++ b/templates/vault_service_bsd_init.j2
@@ -23,7 +23,7 @@ vault_start() {
     for user in ${vault_users}; do
         mkdir /var/run/vault
         chown -R "{{ vault_user }}:{{ vault_group }}" /var/run/vault/
-        su -m "${user}" -c "{{ vault_bin_path }}/vault server -config={{ vault_main_config }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %}&"
+        su -m "${user}" -c "{{ vault_bin_path }}/vault server -config={{ vault_main_config }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %} {{ vault_exec_output }} &"
     done
 }
 

--- a/templates/vault_service_debian_init.j2
+++ b/templates/vault_service_debian_init.j2
@@ -14,7 +14,7 @@ DESC="Vault secret management tool"
 NAME=vault
 DAEMON="{{ vault_bin_path }}/$NAME"
 PIDFILE=/var/run/$NAME/$NAME.pid
-DAEMON_ARGS="server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }}"
+DAEMON_ARGS="server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}"
 USER={{ vault_user }}
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -35,8 +35,8 @@ do_start() {
     mkrundir
     start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile --test > /dev/null \
         || return 1
-    start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid $USER --background --make-pidfile -- \
-        $DAEMON_ARGS \
+    start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $USER --background --make-pidfile --background \
+        --startas /bin/bash -- -c "exec $DAEMON $DAEMON_ARGS" \
         || return 2
 
     RETVAL=0

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -30,7 +30,7 @@ AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK
 {% endif %}
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
-ExecStart={{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }}
+ExecStart=/bin/sh -c '{{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGINT

--- a/templates/vault_sysvinit.j2
+++ b/templates/vault_sysvinit.j2
@@ -41,7 +41,7 @@ start() {
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user={{ vault_user }} \
             --pidfile="$PID_FILE" \
-            "$VAULT" server -config={{ vault_main_config }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %} &
+            "$VAULT" server -config={{ vault_main_config }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %} {{ vault_exec_output }} &
         retcode=$?
         touch /var/lock/subsys/vault
         return $retcode


### PR DESCRIPTION
Follows unfinished PR: https://github.com/ansible-community/ansible-vault/pull/137
* Set default value `vault_exec_output` to `''`
* Update readme with `vault_log_path` and `vault_enable_log`
* Init scripts add `vault_exec_output` content.