### PR TITLE
Allow local installation to be performed as a privileged user

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Sorry, there is no planned support at the moment for Windows.
 
 The role defines variables in `defaults/main.yml`:
 
+### vault_privileged_install
+
+ - Set this to true if you see permission errors when the vault files are
+   downloaded and unpacked locally. This issue can show up if the role has
+   been downloaded by one user (like root), and the installation is done
+   with a different user.
+ - Default value: *false*
+
 ### `vault_version`
 
 - Version to install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ vault_checksum_file_url: "https://releases.hashicorp.com/vault/{{ vault_version 
 
 # Install method variables
 vault_install_remotely: false
+vault_privileged_install: false
 
 # Paths
 vault_bin_path: /usr/local/bin

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,6 +31,7 @@
   get_url:
     url: "{{ vault_checksum_file_url }}"
     dest: "{{ role_path }}/files/{{ vault_shasums }}"
+  become: "{{ vault_privileged_install }}"
   run_once: true
   tags: installation
   when: not vault_checksum.stat.exists | bool
@@ -65,6 +66,7 @@
     dest: "{{ role_path }}/files/{{ vault_pkg }}"
     checksum: "sha256:{{ vault_sha256.stdout }}"
     timeout: "42"
+  become: "{{ vault_privileged_install }}"
   run_once: true
   tags: installation
   when: not vault_package.stat.exists | bool
@@ -75,6 +77,7 @@
     src: "{{ role_path }}/files/{{ vault_pkg }}"
     dest: "{{ role_path }}/files/"
     creates: "{{ role_path }}/files/vault"
+  become: "{{ vault_privileged_install }}"
   run_once: true
   tags: installation
   delegate_to: 127.0.0.1
@@ -94,6 +97,7 @@
   file:
     path: "{{ item }}"
     state: "absent"
+  become: "{{ vault_privileged_install }}"
   with_fileglob: "{{ role_path }}/files/vault"
   run_once: true
   tags: installation

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -31,7 +31,6 @@
   get_url:
     url: "{{ vault_checksum_file_url }}"
     dest: "{{ role_path }}/files/{{ vault_shasums }}"
-  become: false
   run_once: true
   tags: installation
   when: not vault_checksum.stat.exists | bool
@@ -66,7 +65,6 @@
     dest: "{{ role_path }}/files/{{ vault_pkg }}"
     checksum: "sha256:{{ vault_sha256.stdout }}"
     timeout: "42"
-  become: false
   run_once: true
   tags: installation
   when: not vault_package.stat.exists | bool
@@ -77,7 +75,6 @@
     src: "{{ role_path }}/files/{{ vault_pkg }}"
     dest: "{{ role_path }}/files/"
     creates: "{{ role_path }}/files/vault"
-  become: false
   run_once: true
   tags: installation
   delegate_to: 127.0.0.1
@@ -97,7 +94,6 @@
   file:
     path: "{{ item }}"
     state: "absent"
-  become: false
   with_fileglob: "{{ role_path }}/files/vault"
   run_once: true
   tags: installation


### PR DESCRIPTION
Depending on the way the role is installed the local installation
steps will fail with a permission denied error.

Specifically I've encountered the issue in an Vagrant + Ansible Local
setup scenario, where the roles are installed using the pattern
described in the Vagrant docs:

https://archive.is/m8ZgO#install-galaxy-roles-in-a-path-owned-by-root