### PR TITLE
New option to install Vault via HashiCorp Linux Repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ The role defines variables in `defaults/main.yml`:
 - Override this var if you have your sha file is hosted internally
 - Default value: `"https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version}}_SHA256SUMS"`
 
+### `vault_install_hashi_repo`
+
+- Set this to `true` when installing Vault via HashiCorp Linux repository
+- Default value: *false*
+
 ### `vault_shasums`
 
 - SHA summaries filename (included for convenience not for modification)
@@ -448,7 +453,7 @@ starting at Vault version 1.4.
 
 #### `vault_service_registration_check_timeout`
 
-- Specifies the check interval used to send health check information back to Consul. 
+- Specifies the check interval used to send health check information back to Consul.
 - Default value: 5s
 
 #### `vault_service_registration_disable_registration`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ vault_zip_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{
 vault_checksum_file_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version}}_SHA256SUMS"
 
 # Install method variables
+vault_install_hashi_repo: false
 vault_install_remotely: false
 
 # Paths

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -1,0 +1,32 @@
+---
+# File: tasks/install_hashi_repo.yml
+#       Install Vault via HashiCorp Linux repository
+
+- name: Add HashiCorp yum repo
+  command: yum-config-manager --add-repo=https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
+  args:
+    creates: /etc/yum.repos.d/hashicorp.repo
+  when: ansible_pkg_mgr == 'yum'
+
+- name: Install Vault via yum
+  yum:
+    name: "vault-{{ vault_version }}"
+    state: present
+  when: ansible_pkg_mgr == 'yum'
+
+- name: Add HashiCorp apt signing key
+  apt_key:
+    url: https://apt.releases.hashicorp.com/gpg
+    state: present
+  when: ansible_pkg_mgr == 'apt'
+
+- name: Add HashiCorp apt Repo
+  apt_repository:
+    repo: "deb https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    state: present
+  when: ansible_pkg_mgr == 'apt'
+
+- name: Install Vault via apt
+  apt:
+    name: vault={{ vault_version }}
+  when: ansible_pkg_mgr == 'apt'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,7 @@
   when:
     - vault_enterprise | bool
     - not vault_install_remotely | bool
+    - not vault_install_remote_repo | bool
     - installation_required | bool
 
 - name: Install OS packages and Vault via control host
@@ -67,6 +68,15 @@
   when:
     - not vault_enterprise | bool
     - not vault_install_remotely | bool
+    - not vault_install_hashi_repo | bool
+    - installation_required | bool
+
+- name: Install Vault via HashiCorp repository
+  include: install_hashi_repo.yml
+  when:
+    - not vault_enterprise | bool
+    - not vault_install_remotely | bool
+    - vault_install_hashi_repo | bool
     - installation_required | bool
 
 - name: Install OS packages and Vault via remote hosts
@@ -74,6 +84,7 @@
   when:
     - not vault_enterprise | bool
     - vault_install_remotely | bool
+    - not vault_install_hashi_repo | bool
     - installation_required | bool
 
 - name: Check Vault mlock capability


### PR DESCRIPTION
Introduce a new variable `vault_install_hashi_repo` which we can toggle to install Vault via HashiCorp Linux repository.

More info about this new repo can be found in this announcement: https://www.hashicorp.com/blog/announcing-the-hashicorp-linux-repository