### PR TITLE
Update Vault installation check command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
         - vars
 
 - name: Check Vault installation
-  command: command -v vault
+  command: which vault
   environment:
     PATH: "{{ vault_bin_path }}:{{ ansible_env.PATH }}"
   register: vault_installation


### PR DESCRIPTION
This fixes the issue raised in https://github.com/ansible-community/ansible-vault/issues/173

'command' is not found in Debian favour linux which leads to new installation all the time.