### PR TITLE
Fix configuration setting for s3 backend paths.

### DIFF
--- a/templates/vault_backend_s3.j2
+++ b/templates/vault_backend_s3.j2
@@ -17,5 +17,5 @@ storage "s3" {
   session_token = "{{ vault_s3_session_token }}"
   {% endif %}
 
-  vault_s3_force_path_style = "{{ vault_s3_force_path_style }}"
+  s3_force_path_style = "{{ vault_s3_force_path_style }}"
 }


### PR DESCRIPTION
The `vault_backend_s3.j2` template has a setting for `vault_s3_force_path_style`. The actual setting's name is `s3_force_path_style` as per https://www.vaultproject.io/docs/configuration/storage/s3.