### PR TITLE
Fix systemd file

### DIFF
--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -30,7 +30,7 @@ AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK
 {% endif %}
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
-ExecStart=/bin/sh -c '{{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
+ExecStart={{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGINT


### PR DESCRIPTION
Hi there,

`systemctl stop vault` doesn't kill the vault process but only the sh process. Vault process stay as an orphan process.

Directly start the vault process fix that (as in the previous version of the file).

Best