### PR TITLE
Fix systemd service and error redirection

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -154,7 +154,7 @@
 
 - name: "Set Exec output to log path when enabled log"
   set_fact:
-    vault_exec_output: "2>&1 >> {{ vault_log_path }}/vault.log"
+    vault_exec_output: ">> {{ vault_log_path }}/vault.log 2>&1"
   when: vault_enable_log
 
 - name: BSD init script

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -39,7 +39,7 @@ Environment=HTTPS_PROXY={{ vault_https_proxy }}
 {% if vault_no_proxy -%}
 Environment=NO_PROXY={{ vault_no_proxy }}
 {% endif -%}
-ExecStart=/bin/sh -c '{{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
+ExecStart=/bin/sh -c 'exec {{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGINT


### PR DESCRIPTION
Fixes https://github.com/ansible-community/ansible-vault/issues/192

Bash redirection are read from right to left. The error logs were never added to the file because the standard output was written before the error output was redirected to it.

Use `exec` to replace the parent process so that vault actually received the signal sent on stop/restart.