### PR TITLE
move StartLimitInterval, del StartLimitIntervalSec

### DIFF
--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -14,7 +14,7 @@ Documentation=https://www.vaultproject.io/docs/
 Requires=network-online.target
 After=network-online.target
 ConditionFileNotEmpty={{ vault_main_config }}
-StartLimitInterval=60
+
 
 [Service]
 User={{ vault_user }}
@@ -46,7 +46,10 @@ KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
+StartLimitInterval=60
+{% if systemd_version.stdout is version('230', '>=') %}
 StartLimitIntervalSec=60
+{% endif %}
 StartLimitBurst=3
 LimitNOFILE=524288
 LimitNPROC=524288

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -15,7 +15,6 @@ Requires=network-online.target
 After=network-online.target
 ConditionFileNotEmpty={{ vault_main_config }}
 
-
 [Service]
 User={{ vault_user }}
 Group={{ vault_group }}

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -46,9 +46,6 @@ Restart=on-failure
 RestartSec=5
 TimeoutStopSec=30
 StartLimitInterval=60
-{% if systemd_version.stdout is version('230', '>=') %}
-StartLimitIntervalSec=60
-{% endif %}
 StartLimitBurst=3
 LimitNOFILE=524288
 LimitNPROC=524288


### PR DESCRIPTION
Unknown lvalue 'StartLimitInterval' in section 'Unit'
Unknown lvalue 'StartLimitIntervalSec' in section 'Service'

StartLimitInterval= and should be used [Service], not [Unit]
https://github.com/elastic/kibana/pull/47909/files
https://lists.freedesktop.org/archives/systemd-devel/2017-July/039255.html
_This switches our service file to use the older StartLimitInterval configuration. There have been a number of reports of startup errors due to older systemd versions not supporting the newer StartLimitIntervalSec config. The service files are backwards compatible, but not forwards compatible, so this moves back to the old format._