### PR TITLE
Added support for useful options when running Vault behind a load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,15 @@ available starting at Vault version 1.4.
 - Disable Certificate Validation for API reachability check
 - Default value: true
 
+### `vault_proxy_protocol_behavior`
+
+- May be one of `use_always`, `allow_authorized`, or `deny_unauthorized`
+- Enables [PROXY protocol](https://www.vaultproject.io/docs/configuration/listener/tcp#proxy_protocol_behavior) for listener.
+- If enabled and set to something other than `use_always`, you must also set
+  - [*vault_proxy_protocol_authorized_addrs*](https://www.vaultproject.io/docs/configuration/listener/tcp#proxy_protocol_authorized_addrs)
+  - Comma-separated list of source IPs for which PROXY protocol information will be used.
+- Default value: ""
+
 ### `vault_tls_config_path`
 
 - Path to TLS certificate and key
@@ -731,6 +740,16 @@ available starting at Vault version 1.4.
 
 - Copy from remote source if TLS files are already on host
 - Default value: false
+
+### `vault_x_forwarded_for_authorized_addrs`
+
+- Comma-separated list of source IP CIDRs for which an X-Forwarded-For header will be trusted.
+- Enables [X-Forwarded-For support.](https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_authorized_addrs)
+- If enabled, you may also set any of the following parameters:
+  - *vault_x_forwarded_for_hop_skips* with a format of "N" for the number of hops to skip
+  - *vault_x_forwarded_for_reject_not_authorized* with true/false
+  - *vault_x_forwarded_for_reject_not_present* with true/false
+- Default value: "" 
 
 ### `vault_bsdinit_template`
 - BSD init template file

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -11,6 +11,12 @@ plugin_directory = "{{ vault_plugin_path }}"
 listener "tcp" {
   address = "{{ vault_address }}:{{ vault_port }}"
   cluster_address = "{{ vault_cluster_address }}"
+  {% if (vault_proxy_protocol_behavior is defined and vault_proxy_protocol_behavior) -%}
+  proxy_protocol_behavior = "{{ vault_proxy_protocol_behavior }}"
+  {% if (vault_proxy_protocol_authorized_addrs is defined) -%}
+  proxy_protocol_authorized_addrs = "{{ vault_proxy_protocol_authorized_addrs }}"
+  {% endif -%}
+  {% endif -%}
   {% if not (vault_tls_disable | bool) -%}
   tls_cert_file = "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
   tls_key_file = "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
@@ -28,6 +34,18 @@ listener "tcp" {
   {% endif -%}
   {% endif -%}
   tls_disable = "{{ vault_tls_disable | bool | lower }}"
+  {% if (vault_x_forwarded_for_authorized_addrs is defined and vault_x_forwarded_for_authorized_addrs) -%}
+  x_forwarded_for_authorized_addrs = "{{ vault_x_forwarded_for_authorized_addrs }}"
+  {% if (vault_x_forwarded_for_hop_skips is defined) -%}
+  x_forwarded_for_hop_skips = "{{ vault_x_forwarded_for_hop_skips }}"
+  {% endif -%}
+  {% if (vault_x_forwarded_for_reject_not_authorized is defined) -%}
+  x_forwarded_for_reject_not_authorized = "{{ vault_x_forwarded_for_reject_not_authorized | bool | lower }}"
+  {% endif -%}
+  {% if (vault_x_forwarded_for_reject_not_present is defined) -%}
+  x_forwarded_for_reject_not_present = "{{ vault_x_forwarded_for_reject_not_present | bool | lower }}"
+  {% endif -%}
+  {% endif -%}
 }
 
 {#


### PR DESCRIPTION
Vault supports two methods for preserving the client IP when the Vault service is operating behind a load balancer or other type of reverse proxy. This change simply maps these configuration options through from Ansible variables to the vault configuration file.