### PR TITLE
Separate seal config files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -253,6 +253,7 @@ vault_tls_disable_client_certs: false
 
 # awskms seal
 vault_awskms: false
+vault_awskms_config: "{{ vault_config_path }}/vault_awskms.hcl"
 vault_awskms_backend: vault_seal_awskms.j2
 vault_awskms_region: "{{ lookup('env','AWS_DEFAULT_REGION') | default('us-east-1', false) }}"
 vault_awskms_access_key: "{{ lookup('env','AWS_ACCESS_KEY_ID') | default('', false) }}"
@@ -262,6 +263,7 @@ vault_awskms_endpoint: "{{ lookup('env','AWS_KMS_ENDPOINT') | default('', false)
 
 # azurekeyvault seal
 vault_azurekeyvault: false
+vault_azurekeyvault_config: "{{ vault_config_path }}/vault_azurekeyvault.hcl"
 vault_azurekeyvault_backend: vault_seal_azurekeyvault.j2
 
 # gcpkms seal

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -33,6 +33,9 @@
 
 - name: Mask default Vault config from package
   copy:
+    owner: root
+    group: root
+    mode: "0644"
     dest: /etc/vault.d/vault.hcl
     content: |
       # Placeholder to mask default RPM/DPKG Vault config file.

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -30,3 +30,14 @@
   apt:
     name: vault={{ vault_version }}
   when: ansible_pkg_mgr == 'apt'
+
+- name: Mask default Vault config from package
+  copy:
+    dest: /etc/vault.d/vault.hcl
+    content: |
+      # Placeholder to mask default RPM/DPKG Vault config file.
+      #
+      # Package-installed config would interfere with Ansible-managed config files
+      # in this directory. Keeping an empty placeholder prevents package updates
+      # from re-installing the default config.
+  when: ansible_pkg_mgr in ['yum', 'apt']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -140,7 +140,7 @@
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
     mode: "0600"
-  when: vault_gkms | bool
+  when: vault_gkms_credentials_src_file | length | bool
 
 - name: Vault main configuration
   become: true
@@ -151,6 +151,30 @@
     group: "{{ vault_group }}"
     mode: "0400"
     backup: "{{ vault_backup_config | default('false') | bool | lower }}"
+  notify: Restart vault
+
+- name: Vault awskms seal configuration
+  become: true
+  template:
+    src: "{{ vault_awskms_backend }}"
+    dest: "{{ vault_awskms_config }}"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+    mode: "0400"
+    backup: "{{ vault_backup_config | default('false') | bool | lower }}"
+  when: vault_awskms | bool
+  notify: Restart vault
+
+- name: Vault azurekeyvault seal configuration
+  become: true
+  template:
+    src: "{{ vault_azurekeyvault_backend }}"
+    dest: "{{ vault_azurekeyvault_config }}"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+    mode: "0400"
+    backup: "{{ vault_backup_config | default('false') | bool | lower }}"
+  when: vault_azurekeyvault | bool
   notify: Restart vault
 
 - name: "Set Exec output to log path when enabled log"
@@ -228,6 +252,7 @@
   become: true
   systemd:
     daemon-reload: true
+  notify: Restart Vault
   when:
     - ansible_service_mgr == "systemd"
     - not ansible_os_family == "FreeBSD"

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -102,14 +102,6 @@ ui = {{ vault_ui | bool | lower }}
   {% include vault_backend_gkms with context %}
 {% endif %}
 
-{% if vault_awskms | bool -%}
-  {% include vault_awskms_backend with context %}
-{% endif %}
-
-{% if vault_azurekeyvault | bool -%}
-  {% include vault_azurekeyvault_backend with context %}
-{% endif %}
-
 {% if vault_telemetry_enabled | bool -%}
 telemetry {
   {% if vault_statsite_address is defined %}

--- a/templates/vault_service_bsd_init.j2
+++ b/templates/vault_service_bsd_init.j2
@@ -32,7 +32,7 @@ vault_start() {
     for user in ${vault_users}; do
         mkdir /var/run/vault
         chown -R "{{ vault_user }}:{{ vault_group }}" /var/run/vault/
-        su -m "${user}" -c "{{ vault_bin_path }}/vault server -config={{ vault_main_config }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %} {{ vault_exec_output }} &"
+        su -m "${user}" -c "{{ vault_bin_path }}/vault server -config={{ vault_config_path }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %} {{ vault_exec_output }} &"
     done
 }
 

--- a/templates/vault_service_debian_init.j2
+++ b/templates/vault_service_debian_init.j2
@@ -14,7 +14,7 @@ DESC="Vault secret management tool"
 NAME=vault
 DAEMON="{{ vault_bin_path }}/$NAME"
 PIDFILE=/var/run/$NAME/$NAME.pid
-DAEMON_ARGS="server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}"
+DAEMON_ARGS="server -config={{ vault_config_path }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}"
 USER={{ vault_user }}
 SCRIPTNAME=/etc/init.d/$NAME
 

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -28,7 +28,7 @@ Environment=HTTPS_PROXY={{ vault_https_proxy }}
 {% if vault_no_proxy -%}
 Environment=NO_PROXY={{ vault_no_proxy }}
 {% endif -%}
-ExecStart=/bin/sh -c 'exec {{ vault_bin_path }}/vault server -config={{ vault_main_config }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
+ExecStart=/bin/sh -c 'exec {{ vault_bin_path }}/vault server -config={{ vault_config_path }} -log-level={{ vault_log_level | lower }} {{ vault_exec_output }}'
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGINT

--- a/templates/vault_sysvinit.j2
+++ b/templates/vault_sysvinit.j2
@@ -50,7 +50,7 @@ start() {
         [ -f $PID_FILE ] && rm $PID_FILE
         daemon --user={{ vault_user }} \
             --pidfile="$PID_FILE" \
-            "$VAULT" server -config={{ vault_main_config }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %} {{ vault_exec_output }} &
+            "$VAULT" server -config={{ vault_config_path }} {% if vault_log_level is defined %}-log-level={{ vault_log_level | lower }}{% endif %} {{ vault_exec_output }} &
         retcode=$?
         touch /var/lock/subsys/vault
         return $retcode


### PR DESCRIPTION
This splits out the AWS KMS and Azure Key Vault configurations into separate .hcl files, so that `vault_main.hcl` may be managed without providing KMS credentials every time.

This also limits updating the Google KMS credentials file to only when a source file is specified, for the same reason.

Note that it was also necessary to change the Vault command to read the entire `vault.d` configuration directory, rather than just the `vault_main.hcl` file. In my opinion, this is the expected behavior for a *.d configuration directory.

Edit: Resolves #202 