### PR TITLE
Fix exports to user's dotfile

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -246,20 +246,24 @@
 
 - name: Insert http(s) export in dotfile
   become: true
-  become_user: "{{ vault_user }}"
   lineinfile:
     path: "{{ vault_home }}/.bashrc"
+    regexp: "^export VAULT_ADDR="
     line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:{{ vault_port }}'"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
     create: true
   when:
     - ansible_os_family != 'Windows'
 
 - name: Insert CA cert export in dotfile
   become: true
-  become_user: "{{ vault_user }}"
   lineinfile:
     path: "{{ vault_home }}/.bashrc"
+    regexp: "^export VAULT_CACERT="
     line: "export VAULT_CACERT={{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
     create: true
   when:
     - not vault_tls_disable | bool


### PR DESCRIPTION
- Ensure that environment variables wont be duplicated if role is run multiple times with different settings. Good example of this would be a first pass install without TLS and then second pass install with TLS after having generated the SSL certificate using Vault PKI.
    ```
    changed: [dev-env-01] => {"backup": "", "changed": true, "msg": "line replaced"}
   --- before: /home/vault/.bashrc (content)
   +++ after: /home/vault/.bashrc (content)
   @@ -115,4 +115,4 @@
        . /etc/bash_completion
      fi
    fi
   -export VAULT_ADDR='http://10.1.0.12:8200'
   +export VAULT_ADDR='https://10.1.0.12:8200'
   ```
- Replace `become_user` by `owner`+`group` directives. For some reason trying to become "vault" was bugging for me. Better to just set the file ownership on the file from the root account IMO.