### PR TITLE
Update VAULT_ADDR env var to be more TLS friendly

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -247,10 +247,13 @@
 
 - name: Insert http(s) export in dotfile
   become: true
+  # Attempt to help with long lines > 160 issues
+  vars:
+    vault_addr: "{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}"
   lineinfile:
     path: "{{ vault_home }}/.bashrc"
     regexp: "^export VAULT_ADDR="
-    line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_address }}:{{ vault_port }}'"
+    line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_addr }}:{{ vault_port }}'"
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
     create: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -245,11 +245,12 @@
 - name: Restart Vault if needed
   meta: flush_handlers
 
+- name: Compute TLS friendly vault_addr
+  set_fact:
+    vault_addr: "{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}"
+
 - name: Insert http(s) export in dotfile
   become: true
-  # Attempt to help with long lines > 160 issues
-  vars:
-    vault_addr: "{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}"
   lineinfile:
     path: "{{ vault_home }}/.bashrc"
     regexp: "^export VAULT_ADDR="
@@ -280,7 +281,6 @@
   # Attempt to help with long lines > 160 issues
   vars:
     vault_addr_protocol: "{{ vault_tls_disable | ternary('http', 'https') }}"
-    vault_addr: "{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}"
   uri:
     validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
     url: "{{ vault_addr_protocol }}://{{ vault_hostname | default(vault_addr, true) }}:{{ vault_port }}/v1/sys/health"


### PR DESCRIPTION
If the vault_address value is 0.0.0.0 then the exported VAULT_ADDR URL inherits this ip addr. The IP addr being 0.0.0.0 is problematic if TLS certificates are used to communicate using mTLS when neither the server or client certificate include 0.0.0.0 as an IP SAN entry. A common pattern is to include 127.0.0.1 or localhost as SAN entries in TLS certificates so using the same swapping behavior as seen in the [Vault Reachable?](https://github.com/ansible-community/ansible-vault/blob/master/tasks/main.yml#L276) check seemed reasonable.