### PR TITLE
Increase install speed

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,10 +4,9 @@
 - name: OS packages
   become: true
   package:
-    name: "{{ item }}"
+    name: "{{ vault_os_packages }}"
     state: present
     update_cache: true
-  with_items: "{{ vault_os_packages }}"
   tags: installation
 
 # Temporary place for one-off version diff packages, etc.
@@ -15,7 +14,6 @@
   package:
     name: "libcap2-bin"
     state: present
-    update_cache: true
   tags: installation
   when:
     - ansible_distribution == "Debian"

--- a/tasks/install_enterprise.yml
+++ b/tasks/install_enterprise.yml
@@ -4,9 +4,8 @@
 
 - name: OS packages
   package:
-    name: "{{ item }}"
+    name: "{{ vault_os_packages }}"
     state: present
-  with_items: "{{ vault_os_packages }}"
   tags: installation
 
 - name: "[Enterprise] Check {{ role_path }}/files/{{ vault_enterprise_shasums }} (local)"

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -4,9 +4,8 @@
 
 - name: OS packages
   package:
-    name: "{{ item }}"
+    name: "{{ vault_os_packages }}"
     state: present
-  with_items: "{{ vault_os_packages }}"
   tags: installation
 
 - name: Ensure remote vault dir exists


### PR DESCRIPTION
by using package's ability to use list (instead of calling package multiple times which with_items does) and not updating cache twice, we can speed up our code