### PR TITLE
add missing become for task 'OS packages diff'

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,6 +11,7 @@
 
 # Temporary place for one-off version diff packages, etc.
 - name: OS packages diff (Debian 9)
+  become: true
   package:
     name: "libcap2-bin"
     state: present


### PR DESCRIPTION
Add a missing become on task `OS packages diff (Debian 9)`

Without this task, the playbook fails at first install
```
TASK [ansible-community.ansible-vault : OS packages diff (Debian 9)] *************************************************************************************************************************************************************************
[...]
fatal: [vault-5x18]: FAILED! => {"changed": false, "msg": "Failed to lock apt for exclusive operation: Failed to lock directory /var/lib/apt/lists/: E:Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)"}
```