### PR TITLE
add become true for task 'Enable logrotate for vault'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -117,6 +117,7 @@
     - "{{ vault_run_path }}"
 
 - name: Enable logrotate for vault
+  become: true
   template:
     src: "{{ vault_logrotate_template }}"
     dest: /etc/logrotate.d/vault


### PR DESCRIPTION
Add a `become: true` for task `Enable logrotate for vault`

Without this `become`, the task is failing on first run:

```
TASK [ansible-community.ansible-vault : Enable logrotate for vault] **********************************************************************************************************************************************************
fatal: [vault-8hh4]: FAILED! => {"changed": false, "checksum": "b50d72729c3a854e9657984a74a8d8fe1cc93d15", "msg": "Destination /etc/logrotate.d not writable"}
fatal: [vault-vfg2]: FAILED! => {"changed": false, "checksum": "b50d72729c3a854e9657984a74a8d8fe1cc93d15", "msg": "Destination /etc/logrotate.d not writable"}
fatal: [vault-6gsd]: FAILED! => {"changed": false, "checksum": "b50d72729c3a854e9657984a74a8d8fe1cc93d15", "msg": "Destination /etc/logrotate.d not writable"}
```