### PR TITLE
Replace server variable with inventory_hostname in raft configuration

### DIFF
--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -19,14 +19,14 @@ storage "raft" {
   {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
     {% if not (vault_tls_disable | bool) %}
   retry_join {
-    leader_api_addr = "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+    leader_api_addr = "{{ hostvars[inventory_hostname]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[inventory_hostname]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
     leader_ca_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
     leader_client_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
     leader_client_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
   }
     {% else %}
   retry_join {
-    leader_api_addr =  "http://{{ hostvars[server]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"
+    leader_api_addr =  "http://{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"
   }
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
server doesn't seem to have the needed variables for detecting which
interface vault should listen on.

Chaning this to inventory_hostname seems to have access to the correct
variables.

Fixes https://github.com/ansible-community/ansible-vault/issues/211