### PR TITLE
Add a pause after Vault starts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -267,6 +267,13 @@
     name: '{{ vault_systemd_service_name }}'
     state: started
     enabled: true
+  register: start_vault
+
+- name: Pause for 30 seconds to let Vault startup correctly
+  pause:
+    seconds: 30
+  when:
+    - start_vault is changed
 
 - name: Restart Vault if needed
   meta: flush_handlers


### PR DESCRIPTION
I came across an issue where Vault would break it's state if it was
started, then immediatly restarted.

It seems as thought Vault didn't auto-unseal and join the raft cluster
before the restart happened.

To fix this, I added a pause to give Vault enough time to get going.