### PR TITLE
add `when` based on a var for handler `Restart vault`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ specific software and versions:
 
 Sorry, there is no planned support at the moment for Windows.
 
+## Warning
+
+By default, this role may restart `vault` service when played (when there's a
+configuration change, OS Packages installed/updated)
+
+When there's no auto-unseal setup on your cluster, the restart may lead to a
+situation where all Vault instances will be sealed and your cluster will be
+down.
+
+To avoid this situation, the service restart by the playbook can be disabled
+by using the `vault_service_restart` role variable.
+
+Setting this `vault_service_restart` to `false` will disable the `vault`
+service restart by the playbook. You may have to restart the service manually
+to load any new configuration deployed.
+
 ## Role Variables
 
 The role defines variables in `defaults/main.yml`:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ The role defines variables in `defaults/main.yml`:
 - Enable vault web UI
 - Default value:  true
 
+### `vault_service_restart`
+
+- Should the playbook restart Vault service when needed
+- Default value: true
+
 ## TCP Listener Variables
 
 ### `vault_tcp_listeners`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,9 @@ vault_logrotate_freq: 7
 vault_logrotate_template: vault_logrotate.j2
 vault_exec_output: ''
 
+# Handlers
+vault_service_restart: true
+
 # ---------------------------------------------------------------------------
 # Vault variables
 # ---------------------------------------------------------------------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
 - name: Restart vault
   become: true
   service: name='{{ vault_systemd_service_name }}' state=restarted
+  when: vault_service_restart | bool


### PR DESCRIPTION
Adding this condition will allow to choose if the playbook should be
able or not to restart the Vault service

Having this always on true on a production cluster could cause issues
because restarting all Vaults at the same time could end in a fully
sealed Vault cluster