### PR TITLE
Add gcs backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,44 @@ for the DynamoDB storage backend.
 - Default value: none
   - Can be overridden with the environment variable `AWS_SESSION_TOKEN`
 
+### Google Cloud Storage Storage Backend
+
+#### `vault_gcs_bucket`
+
+- Specifies the name of the bucket to use for storage.
+- Default value: none
+
+#### `vault_gcs_ha_enabled`
+
+- Specifies if high availability mode is enabled.
+- Default value: `"false"`
+
+
+#### `vault_gcs_chunk_size`
+
+- Specifies the maximum size (in kilobytes) to send in a single request. If set to 0, it will attempt to send the whole object at once, but will not retry any failures.
+- Default value: `"8192"`
+
+#### `vault_gcs_max_parallel`
+
+- Specifies the maximum number of parallel operations to take place.
+- Default value: `"128"`
+
+#### `vault_gcs_copy_sa`
+
+- Copy GCP SA credentials file from Ansible control node to Vault server. When not `true` and no value is specified for `vault_gcs_credentials_src_file`, the default instance service account credentials are used.
+- Default value: `"false"`
+
+#### `vault_gcs_credentials_src_file`
+
+- Path to GCP SA credential on Ansible control node.
+- Default value: none
+
+#### `vault_gcs_credentials_dst_file`
+
+- Path to SA GCP credential on Vault server.
+- Default value: `{{ vault_home }}/{{ vault_gcs_credentials_src_file | basename}}"`
+
 ### Consul Service Registration
 
 For additional information on the various options, see the

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,6 +104,7 @@ vault_backend_etcd: vault_backend_etcd.j2
 vault_backend_s3: vault_backend_s3.j2
 vault_backend_dynamodb: vault_backend_dynamodb.j2
 vault_backend_mysql: vault_backend_mysql.j2
+vault_backend_gcs: vault_backend_gcs.j2
 
 vault_cluster_disable: false
 vault_cluster_address: "{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"
@@ -174,6 +175,15 @@ vault_mysql_tls_ca_file: ""
 vault_mysql_max_parallel: ""
 vault_mysql_max_idle_connections: ""
 vault_mysql_max_connection_lifetime: ""
+
+# gcs storage settings
+vault_gcs_bucket: ""
+vault_gcs_ha_enabled: false
+vault_gcs_chunk_size: "8192"
+vault_gcs_max_parallel: "128"
+vault_gcs_copy_sa: false
+vault_gcs_credentials_src_file: ""
+vault_gcs_credentials_dst_file: "{{ vault_home }}/{{ vault_gcs_credentials_src_file | basename}}"
 
 # raft storage settings
 vault_backend: raft

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,6 +143,17 @@
     mode: "0600"
   when: vault_gkms_credentials_src_file | length | bool
 
+- name: "Copy GCP Credentials for gcs backend"
+  copy:
+    src: "{{ vault_gcs_credentials_src_file }}"
+    dest: "{{ vault_gcs_credentials_dst_file }}"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+    mode: "0600"
+  when:
+    - vault_backend == "gcs"
+    - vault_gcs_copy_sa | bool
+
 - name: Vault main configuration
   become: true
   template:

--- a/templates/vault_backend_gcs.j2
+++ b/templates/vault_backend_gcs.j2
@@ -1,0 +1,10 @@
+storage "gcs" {
+  bucket       = "{{ vault_gcs_bucket }}"
+  ha_enabled   = "{{ vault_gcs_ha_enabled | bool | lower }}"
+  {% if vault_gcs_chunk_size is defined and vault_gcs_chunk_size|length -%}
+  chunk_size   = "{{ vault_gcs_chunk_size }}"
+  {% endif -%}
+  {% if vault_gcs_max_parallel is defined and vault_gcs_max_parallel|length -%}
+  max_parallel = {{ vault_gcs_max_parallel }}
+  {% endif -%}
+}

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -79,6 +79,8 @@ listener "tcp" {
   {% include vault_backend_dynamodb with context -%}
 {% elif vault_backend == 'mysql' -%}
   {% include vault_backend_mysql with context -%}
+{% elif vault_backend == 'gcs' -%}
+  {% include vault_backend_gcs with context -%}
 {% elif vault_backend == 'raft' -%}
   {% include vault_backend_raft with context -%}
 {% endif %}

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -23,6 +23,9 @@ AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK
 {% endif %}
 CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
 NoNewPrivileges=yes
+{% if vault_gcs_copy_sa and vault_gcs_credentials_src_file is defined and vault_gcs_credentials_dst_file|length -%}
+Environment=GOOGLE_APPLICATION_CREDENTIALS={{ vault_gcs_credentials_dst_file }}
+{% endif -%}
 {% if vault_http_proxy -%}
 Environment=HTTP_PROXY={{ vault_http_proxy }}
 {% endif -%}


### PR DESCRIPTION
Сreated a duplicate of the PR https://github.com/ansible-community/ansible-vault/pull/209 because the previous PR was opened in the develop branch by error.

Added support for [Google Cloud Storage Storage Backend](https://www.vaultproject.io/docs/configuration/storage/google-cloud-storage).

- Added template `vault_backend_gcs.j2`
- Defined vars for gcs backend configuration and the ability to copy user service account credentials file.
```
# gcs storage settings
vault_gcs_bucket: ""
vault_gcs_ha_enabled: false
vault_gcs_chunk_size: "8192"
vault_gcs_max_parallel: "128"
vault_gcs_copy_sa: false
vault_gcs_credentials_src_file: ""
vault_gcs_credentials_dst_file: "{{ vault_home }}/{{ vault_gcs_credentials_src_file | basename}}"
```
- Made changes to `vault_service_systemd.j2` to define ` GOOGLE_APPLICATION_CREDENTIALS` for systemd unit.
```
{% if vault_gcs_copy_sa and vault_gcs_credentials_src_file is defined and vault_gcs_credentials_dst_file|length -%}
Environment=GOOGLE_APPLICATION_CREDENTIALS={{ vault_gcs_credentials_dst_file }}
{% endif -%}
```