### PR TITLE
Revert "Replace server variable with inventory_hostname in raft

### DIFF
--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -19,14 +19,14 @@ storage "raft" {
   {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
     {% if not (vault_tls_disable | bool) %}
   retry_join {
-    leader_api_addr = "{{ hostvars[inventory_hostname]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[inventory_hostname]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+    leader_api_addr = "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
     leader_ca_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
     leader_client_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
     leader_client_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
   }
     {% else %}
   retry_join {
-    leader_api_addr =  "http://{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"
+    leader_api_addr =  "http://{{ hostvars[server]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"
   }
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
This change breaks the loop

It will also destroy any raft cluster with several nodes

For each Vault instance, there will be a list of X `leader_api_addr`
but always the same: the `inventory_hostname` of the current instance

This reverts commit b5e2f7b68af1025f451312d16a4c8d4986e5e4a9.