### PR TITLE
add possibility to customize wait time after the first Vault start

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ The role defines variables in `defaults/main.yml`:
 - Should the playbook restart Vault service when needed
 - Default value: true
 
+### `vault_start_pause_seconds`
+
+- Some installations may need some time between the first Vault start
+  and the first restart. Setting this to a value `>0` will add a pause
+  time after the first Vault start.
+- Default value: 0
+
 ## TCP Listener Variables
 
 ### `vault_tcp_listeners`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,9 @@ vault_shasums: "vault_{{ vault_version }}_SHA256SUMS"
 vault_zip_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version }}_{{ vault_os }}_{{ vault_architecture }}.zip"
 vault_checksum_file_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version}}_SHA256SUMS"
 
+# Installation
+vault_start_pause_seconds: 0
+
 # Install method variables
 vault_install_hashi_repo: false
 vault_install_remotely: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -280,11 +280,12 @@
     enabled: true
   register: start_vault
 
-- name: Pause for 30 seconds to let Vault startup correctly
+- name: Pause for {{ vault_start_pause }} seconds to let Vault startup correctly
   pause:
-    seconds: 30
+    seconds: "{{ vault_start_pause }}"
   when:
     - start_vault is changed
+    - vault_start_pause_seconds | int > 0
 
 - name: Restart Vault if needed
   meta: flush_handlers


### PR DESCRIPTION
Waiting 30 seconds for each playbook run shouldn't be a default
value as it's only impacting a few users.

It very time consuming especially for playbook runs with `serial`
and multiple nodes clusters (5 nodes: 2mn30s wait time)