### PR TITLE
add doc and fix vault_install_remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ The role defines variables in `defaults/main.yml`:
 - Set this to `true` when installing Vault via HashiCorp Linux repository
 - Default value: *false*
 
+### `vault_install_remotely`
+
+- Set this to `true` will download Vault binary from each target instead of localhost
+- Default value: *false*
+
 ### `vault_shasums`
 
 - SHA summaries filename (included for convenience not for modification)

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -3,6 +3,7 @@
 #       Package installation tasks for vault
 
 - name: OS packages
+  become: true
   package:
     name: "{{ vault_os_packages }}"
     state: present
@@ -49,6 +50,7 @@
   when: not vault_package.stat.exists | bool
 
 - name: Unarchive Vault and install binary
+  become: true
   unarchive:
     remote_src: true
     src: "/tmp/vault/{{ vault_pkg }}"


### PR DESCRIPTION
This option wasn't documented anymore

By default the playbook downloads the Vault binary on the controller host then push it to all targets

Setting this variable to `true` do the download directly from the targets