### PR TITLE
add Raft cloud auto join settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,33 @@ vault_tcp_listeners:
 - Interval after which autopilot will pick up any state changes
 - Default value: none
 
+#### `vault_raft_cloud_auto_join`
+
+- Defines any cloud auto-join metadata. If supplied, Vault will
+  attempt to automatically discover peers in addition to what can
+  be provided via `leader_api_addr`
+- Default value: none
+
+#### `vault_raft_cloud_auto_join_exclusive`
+
+- If set to `true`, any `leader_api_addr` occurences will be removed
+  from the configuration.
+  Keeping this to `false` will allow `auto_join` and `leader_api_addr`
+  to coexist
+- Default value: false
+
+#### `vault_raft_cloud_auto_join_scheme`
+
+- URI scheme to be used for `auto_join`
+- Default value: none (`https` is the default value set by
+  Vault if not specified)
+
+#### `vault_raft_cloud_auto_join_port`
+
+- Port to be used for `auto_join`
+- Default value: none (`8200` is the default value set by
+  Vault if not specified)
+
 ### Consul Storage Backend
 
 #### `vault_backend_consul`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -198,6 +198,10 @@ vault_raft_node_id: "{{ lookup('env', 'VAULT_RAFT_NODE_ID') | default(inventory
 # vault_raft_snapshot_threshold:
 # vault_raft_max_entry_size:
 # vault_raft_autopilot_reconcile_interval:
+# vault_raft_cloud_auto_join:
+# vault_raft_cloud_auto_join_scheme:
+# vault_raft_cloud_auto_join_port:
+vault_raft_cloud_auto_join_exclusive: false
 
 # ---------------------------------------------------------------------------
 # Service registration variables

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -16,6 +16,18 @@ storage "raft" {
   {% if vault_raft_autopilot_reconcile_interval is defined and vault_raft_autopilot_reconcile_interval %}
   autopilot_reconcile_interval = "{{ vault_raft_autopilot_reconcile_interval }}"
   {% endif %}
+  {% if vault_raft_cloud_auto_join is defined and vault_raft_cloud_auto_join %}
+  retry_join {
+    auto_join = "{{ vault_raft_cloud_auto_join }}"
+    {% if vault_raft_cloud_auto_join_scheme is defined and vault_raft_cloud_auto_join_scheme %}
+    auto_join_scheme = "{{ vault_raft_cloud_auto_join_scheme }}"
+    {% endif %}
+    {% if vault_raft_cloud_auto_join_port is defined and vault_raft_cloud_auto_join_port %}
+    auto_join_port = "{{ vault_raft_cloud_auto_join_port }}"
+    {% endif %}
+  }
+  {% endif %}
+  {% if not vault_raft_cloud_auto_join_exclusive %}
   {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
     {% if not (vault_tls_disable | bool) %}
   retry_join {
@@ -30,6 +42,7 @@ storage "raft" {
   }
     {% endif %}
   {% endfor %}
+  {% endif %}
 }
 
 // HashiCorp recommends disabling mlock when using Raft.


### PR DESCRIPTION
Add Raft cloud auto join settings

Hashicorp documentation can be found here
https://www.vaultproject.io/docs/configuration/storage/raft#retry_join-stanza