### PR TITLE
Disable core dumps in Vault

### DIFF
--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -47,6 +47,7 @@ StartLimitBurst=3
 LimitNOFILE=524288
 LimitNPROC=524288
 LimitMEMLOCK=infinity
+LimitCORE=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hashicorp recommend turning off core dumps:
https://learn.hashicorp.com/tutorials/vault/production-hardening