### PR TITLE
distro: add support for Flatcar Linux

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,9 @@ vault_manage_group: false
 vault_group: bin
 vault_groups: null
 
+vault_dotfile: ".bashrc"
+vault_dotfile_disable: false
+
 # Logging
 vault_enable_log: false
 vault_enable_logrotate: false
@@ -245,6 +248,7 @@ vault_sysvinit_template: vault_sysvinit.j2
 vault_debian_init_template: vault_service_debian_init.j2
 vault_systemd_template: vault_service_systemd.j2
 vault_systemd_service_name: vault
+vault_systemd_unit_path: /lib/systemd/system
 
 # ---------------------------------------------------------------------------
 # TLS variables

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -4,7 +4,9 @@
 - name: Check distribution compatibility
   fail:
     msg: "{{ ansible_distribution }} is not supported by this role"
-  when: ansible_distribution not in ['RedHat', 'CentOS', 'Fedora', 'Debian', 'Ubuntu', 'Archlinux', 'OracleLinux']
+  when:
+    - ansible_distribution not in _vault_nix_distros
+    - ansible_os_family != 'Windows'
 
 - name: Fail if not a new release of Red Hat / CentOS
   fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -248,7 +248,7 @@
   become: true
   template:
     src: "{{ vault_systemd_template }}"
-    dest: "/lib/systemd/system/{{ vault_systemd_service_name }}.service"
+    dest: "{{ vault_systemd_unit_path }}/{{ vault_systemd_service_name }}.service"
     force: true
     owner: root
     group: root
@@ -297,7 +297,7 @@
 - name: Insert http(s) export in dotfile
   become: true
   lineinfile:
-    path: "{{ vault_home }}/.bashrc"
+    path: "{{ vault_home }}/{{ vault_dotfile }}"
     regexp: "^export VAULT_ADDR="
     line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_addr }}:{{ vault_port }}'"
     owner: "{{ vault_user }}"
@@ -305,12 +305,13 @@
     create: true
     mode: 0600
   when:
+    - not vault_dotfile_disable
     - ansible_os_family != 'Windows'
 
 - name: Insert CA cert export in dotfile
   become: true
   lineinfile:
-    path: "{{ vault_home }}/.bashrc"
+    path: "{{ vault_home }}/{{ vault_dotfile }}"
     regexp: "^export VAULT_CACERT="
     line: "export VAULT_CACERT={{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
     owner: "{{ vault_user }}"
@@ -318,6 +319,7 @@
     create: true
     mode: 0600
   when:
+    - not vault_dotfile_disable
     - not vault_tls_disable | bool
     - ansible_os_family != 'Windows'
 

--- a/vars/Flatcar.yml
+++ b/vars/Flatcar.yml
@@ -1,0 +1,10 @@
+---
+# File: vars/Flatcar.yml - Flatcar Linux vars for Vault
+
+vault_os_packages: []
+
+vault_systemd_unit_path: /etc/systemd/system
+
+vault_bin_path: /opt/bin
+
+vault_plugin_path: /opt/vault/plugins

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,15 @@ vault_http_status:
   '473': 'performance standby'
   '501': 'not initialized'
   '503': 'sealed'
+
+# Supported *nix distributions
+_vault_nix_distros:
+  - 'RedHat'
+  - 'CentOS'
+  - 'Fedora'
+  - 'Debian'
+  - 'Ubuntu'
+  - 'Archlinux'
+  - 'OracleLinux'
+  - 'Flatcar'
+  - 'FreeBSD'


### PR DESCRIPTION
 - make dotfile name configurable
   and possible to opt out of dotfile
   creation.

 - make systemd unit path configurable as
   some distros have /lib/systemd/system
   readonly.

- add Flatcar.yml to vars folder with
   appropriate distro settings.

- add `_vault_nix_distros` list with
   supported *nix distributions.
