### PR TITLE
Rename vault_start_pause to vault_start_pause_seconds

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -280,9 +280,9 @@
     enabled: true
   register: start_vault
 
-- name: Pause for {{ vault_start_pause }} seconds to let Vault startup correctly
+- name: Pause for {{ vault_start_pause_seconds }} seconds to let Vault startup correctly
   pause:
-    seconds: "{{ vault_start_pause }}"
+    seconds: "{{ vault_start_pause_seconds }}"
   when:
     - start_vault is changed
     - vault_start_pause_seconds | int > 0


### PR DESCRIPTION
vault_start_pause isn't defined anywhere, use vault_start_pause_seconds
instead.

Related to https://github.com/ansible-community/ansible-vault/pull/238