### PR TITLE
Fix log rotate

### DIFF
--- a/templates/vault_logrotate.j2
+++ b/templates/vault_logrotate.j2
@@ -1,6 +1,7 @@
 {{ vault_log_path }}/vault.log
 {
     missingok
+    copytruncate
     rotate {{ vault_logrotate_freq }}
     daily
     dateext


### PR DESCRIPTION
Log rotate doesnt currently work, once logs have rotated it still points
to the old file handler. This will ensure the logs function correctly once
it has rotated.