### PR TITLE
remote_install: only install OS packages if non-empty

### DIFF
--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -8,6 +8,7 @@
     name: "{{ vault_os_packages }}"
     state: present
   tags: installation
+  when: (vault_os_packages is defined) and (vault_os_packages | length > 0)
 
 - name: Ensure remote vault dir exists
   file:


### PR DESCRIPTION
@bbaassssiiee WDYT? Same thing as with #250 (avoiding failure when using Flatcar or Fedora CoreOS)