### PR TITLE
Optionally set proxy when Vault API reachable check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -328,6 +328,8 @@
   # Attempt to help with long lines > 160 issues
   vars:
     vault_addr_protocol: "{{ vault_tls_disable | ternary('http', 'https') }}"
+  environment:
+    no_proxy: "{{ vault_address }}"
   uri:
     validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
     url: "{{ vault_addr_protocol }}://{{ vault_hostname | default(vault_addr, true) }}:{{ vault_port }}/v1/sys/health"


### PR DESCRIPTION
Add default boolean variable 'use_proxy_during_api_reachable_check' to
control whether proxy shall be used when vault api reachable task is
executed