### PR TITLE
add vault_raft_tls_servername option

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,10 @@ vault_tcp_listeners:
 - {{ vault_tls_ca_file }}
 
 ### Raft Storage Backend
+#### `vault_raft_leader_tls_servername`
+
+- TLS servername to use when connecting with HTTPS
+- Default value: none
 
 #### `vault_raft_group_name`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -199,6 +199,7 @@ vault_backend: raft
 vault_raft_group_name: "vault_raft_servers"
 vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"
 vault_raft_node_id: "{{ lookup('env', 'VAULT_RAFT_NODE_ID') | default(inventory_hostname_short, true) }}"
+# vault_raft_leader_tls_servername
 # vault_raft_performance_multiplier:
 # vault_raft_trailing_logs:
 # vault_raft_snapshot_threshold:

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -32,6 +32,9 @@ storage "raft" {
     {% if not (vault_tls_disable | bool) %}
   retry_join {
     leader_api_addr = "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+    {% if vault_raft_leader_tls_servername is defined %}
+    leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
+    {% endif %}
     leader_ca_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
     leader_client_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
     leader_client_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"


### PR DESCRIPTION
This adds the leader_tls_servername (https://www.vaultproject.io/docs/configuration/storage/raft#leader_tls_servername)