### PR TITLE
Fix enterprise install

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -24,7 +24,7 @@ jobs:
         id: set-scenarios
         # Find path to all scenarios
         run: |
-          export scenarios="[`for x in $(ls -1 molecule -I _tests -I '*.yml'); do echo "'$x'"; done | tr '\n' ',' | sed '$s/,$//'`]"
+          export scenarios="[`for x in $(ls -1 molecule -I inventory -I _tests -I '*.yml'); do echo "'$x'"; done | tr '\n' ',' | sed '$s/,$//'`]"
           echo "::set-output name=scenarios::$scenarios"
 
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ cache/
 examples/hosts
 files/vault
 files/vault*_SHA256SUMS
+files/EULA.txt
+files/TermsOfEvaluation.txt
 meta/.galaxy_install_info

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,3 +45,4 @@ Thank you to all these fine folks for helping with ansible-vault!
 - [@zeridon](https://github.com/zeridon)
 - [@akerouanton](https://github.com/akerouanton)
 - [@elcomtik](https://github.com/elcomtik)
+- [@FalcoSuessgott](https://github.com/falcosuessgott)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+default: help
+
+.PHONY: help
+help: ## list makefile targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: lint
+lint: ## lint all scenarios
+	for scenario in $(shell ls molecule); do \
+		molecule lint -s $$scenario; \
+	done
+
+.PHONY: test
+test: ## test all scenarios
+	for scenario in $(shell ls molecule); do \
+		molecule test -s $$scenario; \
+		$(MAKE) clean; \
+	done
+
+.PHONY: clean
+clean: ## clean temporary files
+	rm -rf files/EULA.txt files/TermsOfEvaluation.txt files/vault files/vault_*

--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ The role defines variables in `defaults/main.yml`:
 
 - Version to install
   - Can be overridden with `VAULT_VERSION` environment variable
-  - Will include "+prem" if vault_enterprise_premium=True
-  - Will include ".hsm" if vault_enterprise_premium_hsm=True
+  - Will include `+ent` if `vault_enterprise_premium=True` (cannot be used in conjunction with `vault_enterprise_premium_hsm=True`)
+  - Will include `+.ent.hsm` if `vault_enterprise_premium_hsm=True` (cannot be used in conjunction with `vault_enterprise_premium=True`)
 
-- Default value: 1.5.5
+- Default value: `1.8.4`
 
 ### `vault_enterprise`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 # ---------------------------------------------------------------------------
 
 # Package variables
-vault_version: "{{ lookup('env', 'VAULT_VERSION') | default('1.5.5', true) }}{{ '+prem' if vault_enterprise_premium else '' }}{{ '.hsm' if vault_enterprise_premium_hsm else '' }}"
+vault_version: "{{ lookup('env', 'VAULT_VERSION') | default('1.12.0', true) }}"
 vault_architecture_map:
   # this first entry seems... redundant (but it's required for reasons)
   amd64: amd64
@@ -372,8 +372,8 @@ vault_entropy_seal: false
 # ---------------------------------------------------------------------------
 
 vault_enterprise: "{{ lookup('env', 'VAULT_ENTERPRISE') | default(false, true) }}"
-vault_enterprise_pkg: "vault-enterprise_{{ vault_version }}_{{ vault_os }}_{{ vault_architecture }}.zip"
-vault_enterprise_shasums: "vault-enterprise_{{ vault_version }}_SHA256SUMS"
+vault_enterprise_pkg: "vault_{{ vault_version }}_{{ vault_os }}_{{ vault_architecture }}.zip"
+vault_enterprise_shasums: "vault_{{ vault_version }}_SHA256SUMS"
 vault_enterprise_premium: false
 
 # Manage enterprise license file with this role
@@ -394,6 +394,7 @@ vault_plugins_src_dir_local: "{{ role_path }}/files/plugins"  # Directory for st
 vault_plugins_src_dir_cleanup: false  # Cleanup vault plugin src/zip dir after plugin install. WARNING: could cause plugins to be downloaded each time.
 
 # vault acme plugin
+vault_plugin_install: false
 vault_plugin_acme_install: remote  # remote / local
 vault_plugin_acme_sidecar_install: false
 vault_plugin_acme_version: "latest"

--- a/molecule/almalinux-8/molecule.yml
+++ b/molecule/almalinux-8/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: almalinux-8
     groups:
-      - vault_raft_servers
+      - almalinux-8
     image: dokken/almalinux-8
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: almalinux-8_repo
+  - name: almalinux-8-repo
     groups:
-      - vault_raft_servers
+      - almalinux-8-repo
+      - repo
     image: dokken/almalinux-8
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: almalinux-8-enterprise
+    groups:
+      - almalinux-8-enterprise
+      - enterprise
+    image: dokken/almalinux-8
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: almalinux-8-repo-enterprise
+    groups:
+      - almalinux-8-repo-enterprise
+      - enterprise
+      - repo
+    image: dokken/almalinux-8
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      almalinux-8_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/almalinux-9/molecule.yml
+++ b/molecule/almalinux-9/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: almalinux-9
     groups:
-      - vault_raft_servers
+      - almalinux-9
     image: dokken/almalinux-9
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: almalinux-9_repo
+  - name: almalinux-9-repo
     groups:
-      - vault_raft_servers
+      - almalinux-9-repo
+      - repo
     image: dokken/almalinux-9
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: almalinux-9-enterprise
+    groups:
+      - almalinux-9-enterprise
+      - enterprise
+    image: dokken/almalinux-9
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: almalinux-9-repo-enterprise
+    groups:
+      - almalinux-9-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/almalinux-9
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      almalinux-9_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/amazonlinux-2/molecule.yml
+++ b/molecule/amazonlinux-2/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: amazonlinux-2
     groups:
-      - vault_raft_servers
+      - amazonlinux-2
     image: dokken/amazonlinux-2
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: amazonlinux-2_repo
+  - name: amazonlinux-2-repo
     groups:
-      - vault_raft_servers
+      - amazonlinux-2-repo
+      - repo
     image: dokken/amazonlinux-2
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: amazonlinux-2-enterprise
+    groups:
+      - amazonlinux-2-enterprise
+      - enterprise
+    image: dokken/amazonlinux-2
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: amazonlinux-2-repo-enterprise
+    groups:
+      - amazonlinux-2-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/amazonlinux-2
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      amazonlinux-2_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/amazonlinux-2022/molecule.yml
+++ b/molecule/amazonlinux-2022/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: amazonlinux-2022
     groups:
-      - vault_raft_servers
+      - amazonlinux-2022
     image: dokken/amazonlinux-2022
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: amazonlinux-2022_repo
+  - name: amazonlinux-2022-repo
     groups:
-      - vault_raft_servers
+      - amazonlinux-2022-repo
+      - repo
     image: dokken/amazonlinux-2022
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: amazonlinux-2022-enterprise
+    groups:
+      - amazonlinux-2022-enterprise
+      - enterprise
+    image: dokken/amazonlinux-2022
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: amazonlinux-2022-repo-enterprise
+    groups:
+      - amazonlinux-2022-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/amazonlinux-2022
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      amazonlinux-2022_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/centos-7/molecule.yml
+++ b/molecule/centos-7/molecule.yml
@@ -2,27 +2,45 @@
 platforms:
   - name: centos-7
     groups:
-      - vault_raft_servers
+      - centos-7
     image: dokken/centos-7
     command: /usr/lib/systemd/systemd
     dockerfile: Dockerfile.j2
     pre_build_image: false
     privileged: true
     cgroup_parent: docker.slice
-  - name: centos-7_repo
+  - name: centos-7-repo
     groups:
-      - vault_raft_servers
+      - centos-7-repo
+      - repo
     image: dokken/centos-7
     command: /usr/lib/systemd/systemd
     dockerfile: Dockerfile.j2
     pre_build_image: false
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: centos-7-enterprise
+    groups:
+      - centos-7-enterprise
+      - enterprise
+    image: dokken/centos-7
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: centos-7-repo-enterprise
+    groups:
+      - centos-7_repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/centos-7
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      centos-7_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/centos-stream-8/molecule.yml
+++ b/molecule/centos-stream-8/molecule.yml
@@ -2,25 +2,45 @@
 platforms:
   - name: centos-stream-8
     groups:
-      - vault_raft_servers
+      - centos-stream-8
     image: dokken/centos-stream-8
-    pre_build_image: true
-    command: /lib/systemd/systemd
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
     privileged: true
     cgroup_parent: docker.slice
-  - name: centos-stream-8_repo
+  - name: centos-stream-8-repo
     groups:
-      - vault_raft_servers
+      - centos-stream-8-repo
+      - repo
     image: dokken/centos-stream-8
-    pre_build_image: true
-    command: /lib/systemd/systemd
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: centos-stream-8-enterprise
+    groups:
+      - centos-stream-8-enterprise
+      - enterprise
+    image: dokken/centos-stream-8
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: centos-stream-8-repo-enterprise
+    groups:
+      - centos-stream-8-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/centos-stream-stream-8
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      centos-stream-8_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/centos-stream-9/molecule.yml
+++ b/molecule/centos-stream-9/molecule.yml
@@ -2,25 +2,45 @@
 platforms:
   - name: centos-stream-9
     groups:
-      - vault_raft_servers
+      - centos-stream-9
     image: dokken/centos-stream-9
-    pre_build_image: true
-    command: /lib/systemd/systemd
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
     privileged: true
     cgroup_parent: docker.slice
-  - name: centos-stream-9_repo
+  - name: centos-stream-9-repo
     groups:
-      - vault_raft_servers
+      - centos-stream-9-repo
+      - repo
     image: dokken/centos-stream-9
-    pre_build_image: true
-    command: /lib/systemd/systemd
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: centos-stream-9-enterprise
+    groups:
+      - centos-stream-9-enterprise
+      - enterprise
+    image: dokken/centos-stream-9
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: centos-stream-9-repo-enterprise
+    groups:
+      - centos-stream-9-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/centos-stream-stream-9
+    command: /usr/lib/systemd/systemd
+    dockerfile: Dockerfile.j2
+    pre_build_image: false
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      centos-stream-9_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/debian-10/molecule.yml
+++ b/molecule/debian-10/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: debian-10
     groups:
-      - vault_raft_servers
+      - debian-10
     image: dokken/debian-10
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: debian-10_repo
+  - name: debian-10-enterprise
     groups:
-      - vault_raft_servers
+      - debian-10-enterprise
+      - enterprise
     image: dokken/debian-10
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: debian-10-repo
+    groups:
+      - debian-10-repo
+      - repo
+    image: dokken/debian-10
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: debian-10-repo-enterprise
+    groups:
+      - debian-10-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/debian-10
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      debian-10_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/debian-11/molecule.yml
+++ b/molecule/debian-11/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: debian-11
     groups:
-      - vault_raft_servers
+      - debian-11
     image: dokken/debian-11
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: debian-11_repo
+  - name: debian-11-enterprise
     groups:
-      - vault_raft_servers
+      - debian-11-enterprise
+      - enterprise
     image: dokken/debian-11
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: debian-11-repo
+    groups:
+      - debian-11-repo
+      - repo
+    image: dokken/debian-11
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: debian-11-repo-enterprise
+    groups:
+      - debian-11-repo-enterprise
+      - repo
+      - enterprie
+    image: dokken/debian-11
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      debian-11_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/debian-9/molecule.yml
+++ b/molecule/debian-9/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: debian-9
     groups:
-      - vault_raft_servers
+      - debian-9
     image: dokken/debian-9
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: debian-9_repo
+  - name: debian-9-enterprise
     groups:
-      - vault_raft_servers
+      - debian-9-enterprise
+      - enterprise
     image: dokken/debian-9
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: debian-9-repo
+    groups:
+      - debian-9-repo
+      - repo
+    image: dokken/debian-9
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: debian-9-repo-enterprise
+    groups:
+      - debian-9-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/debian-9
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      debian-9_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/inventory/group_vars/all.yml
+++ b/molecule/inventory/group_vars/all.yml
@@ -1,0 +1,2 @@
+---
+vault_raft_group_name: "{{ ansible_hostname }}"

--- a/molecule/inventory/group_vars/enterprise.yml
+++ b/molecule/inventory/group_vars/enterprise.yml
@@ -1,0 +1,4 @@
+---
+vault_enterprise: true
+vault_enterprise_premium: true
+vault_disable_api_health_check: true

--- a/molecule/inventory/group_vars/repo.yml
+++ b/molecule/inventory/group_vars/repo.yml
@@ -1,0 +1,4 @@
+---
+vault_install_hashi_repo: true
+vault_bin_path: /usr/bin
+vault_group: vault

--- a/molecule/rockylinux-8/molecule.yml
+++ b/molecule/rockylinux-8/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: rockylinux-8
     groups:
-      - vault_raft_servers
+      - rockylinux-8
     image: dokken/rockylinux-8
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: rockylinux-8_repo
+  - name: rockylinux-8-repo
     groups:
-      - vault_raft_servers
+      - rockylinux-8-repo
+      - repo
     image: dokken/rockylinux-8
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: rockylinux-8-enterprise
+    groups:
+      - rockylinux-8-enterprise
+      - enterprise
+    image: dokken/rockylinux-8
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: rockylinux-8-repo-enterprise
+    groups:
+      - rockylinux-8-repo-enterprise
+      - enterprise
+      - repo
+    image: dokken/rockylinux-8
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      rockylinux-8_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/rockylinux-9/molecule.yml
+++ b/molecule/rockylinux-9/molecule.yml
@@ -2,25 +2,40 @@
 platforms:
   - name: rockylinux-9
     groups:
-      - vault_raft_servers
+      - rockylinux-9
     image: dokken/rockylinux-9
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: rockylinux-9_repo
+  - name: rockylinux-9-repo
     groups:
-      - vault_raft_servers
+      - rockylinux-9-repo
     image: dokken/rockylinux-9
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: rockylinux-9-enterprise
+    groups:
+      - rockylinux-9-enterprise
+      - enterprise
+    image: dokken/rockylinux-9
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: rockylinux-9-repo-enterprise
+    groups:
+      - rockylinux-9-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/rockylinux-9
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      rockylinux-9_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/ubuntu-18.04/molecule.yml
+++ b/molecule/ubuntu-18.04/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: ubuntu-18.04
     groups:
-      - vault_raft_servers
+      - ubuntu-18.04
     image: dokken/ubuntu-18.04
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: ubuntu-18.04_repo
+  - name: ubuntu-18.04-repo
     groups:
-      - vault_raft_servers
+      - ubuntu-18.04-repo
+      - enterprise
     image: dokken/ubuntu-18.04
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: ubuntu-18.04-enterprise
+    groups:
+      - ubuntu-18.04-enterprise
+      - enterprise
+    image: dokken/ubuntu-18.04
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: ubuntu-18.04-repo-enterprise
+    groups:
+      - ubuntu-18.04-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/ubuntu-18.04
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      ubuntu-18.04_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/ubuntu-20.04/molecule.yml
+++ b/molecule/ubuntu-20.04/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: ubuntu-20.04
     groups:
-      - vault_raft_servers
+      - ubuntu-20.04
     image: dokken/ubuntu-20.04
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: ubuntu-20.04_repo
+  - name: ubuntu-20.04-repo
     groups:
-      - vault_raft_servers
+      - ubuntu-20.04-repo
+      - repo
     image: dokken/ubuntu-20.04
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: ubuntu-20.04-enterprise
+    groups:
+      - ubuntu-20.04-enterprise
+      - enterprise
+    image: dokken/ubuntu-20.04
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: ubuntu-20.04-repo-enterprise
+    groups:
+      - ubuntu-20.04-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/ubuntu-20.04
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      ubuntu-20.04_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/molecule/ubuntu-22.04/molecule.yml
+++ b/molecule/ubuntu-22.04/molecule.yml
@@ -2,25 +2,41 @@
 platforms:
   - name: ubuntu-22.04
     groups:
-      - vault_raft_servers
+      - ubuntu-22.04
     image: dokken/ubuntu-22.04
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-  - name: ubuntu-22.04_repo
+  - name: ubuntu-22.04-repo
     groups:
-      - vault_raft_servers
+      - ubuntu-22.04-repo
+      - repo
     image: dokken/ubuntu-22.04
     pre_build_image: true
     command: /lib/systemd/systemd
     privileged: true
     cgroup_parent: docker.slice
-
+  - name: ubuntu-22.04-enterprise
+    groups:
+      - ubuntu-22.04-enterprise
+      - enterprise
+    image: dokken/ubuntu-22.04
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
+  - name: ubuntu-22.04-repo-enterprise
+    groups:
+      - ubuntu-22.04-repo-enterprise
+      - repo
+      - enterprise
+    image: dokken/ubuntu-22.04
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    privileged: true
+    cgroup_parent: docker.slice
 provisioner:
   inventory:
-    host_vars:
-      ubuntu-22.04_repo:
-        vault_install_hashi_repo: true
-        vault_bin_path: /usr/bin
-        vault_group: vault
+    links:
+      group_vars: ../inventory/group_vars/

--- a/tasks/asserts.yml
+++ b/tasks/asserts.yml
@@ -1,6 +1,5 @@
 ---
 # File: tasks/asserts.yml - Asserts for this role
-
 - name: Check distribution compatibility
   fail:
     msg: "{{ ansible_distribution }} is not supported by this role"
@@ -47,3 +46,9 @@
   when:
     - vault_transit | bool
     - not (vault_transit_address or vault_transit_token)
+
+- name: Fail if vault_enterprise and vault_enterprise_premium_hsm set to True
+  fail:
+    msg: "cannot use both vault_enterprise and vault_enterprise_premium_hsm set to True"
+  when:
+    - vault_enterprise and vault_enterprise_premium_hsm

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -46,7 +46,7 @@
   unarchive:
     src: "{{ role_path }}/files/{{ vault_pkg }}"
     dest: "{{ role_path }}/files/"
-    creates: "{{ role_path }}/files/vault"
+    # creates: "{{ role_path }}/files/vault"
   become: "{{ vault_privileged_install }}"
   run_once: true
   tags: installation

--- a/tasks/install_enterprise.yml
+++ b/tasks/install_enterprise.yml
@@ -8,26 +8,17 @@
     state: present
   tags: installation
 
-- name: "[Enterprise] Check vault_enterprise_shasums (local)"
-  stat:
-    path: "{{ role_path }}/files/{{ vault_enterprise_shasums }}"
+- name: "[Enterprise] Download checksum file locally from {{ vault_checksum_file_url }}"
+  uri:
+    url: "{{ vault_checksum_file_url }}"
+    dest: "{{ role_path }}/files/{{ vault_enterprise_shasums }}"
+    method: GET
+    status_code:
+      - 200
+      - 304
   become: false
   run_once: true
   register: vault_checksum
-  delegate_to: 127.0.0.1
-
-- name: "[Enterprise] Get SHA SUM from {{ role_path }}/files/{{ vault_enterprise_shasums }} (local)"
-  shell: |
-    set -o pipefail
-    grep "{{ vault_enterprise_pkg }}" "{{ role_path }}/files/{{ vault_enterprise_shasums }}" | awk '{print $1}'
-  args:
-    executable: /bin/bash
-  become: false
-  run_once: true
-  register: vault_sha256
-  tags:
-    - installation
-    - skip_ansible_lint
   delegate_to: 127.0.0.1
 
 - name: "[Enterprise] Check vault_enterprise_pkg (local)"
@@ -40,26 +31,26 @@
 
 - name: "[Enterprise] Download vault (local)"
   get_url:
-    url: "{{ vault_zip_url }}/{{ vault_enterprise_pkg }}"
+    url: "{{ vault_zip_url }}"
     dest: "{{ role_path }}/files/{{ vault_enterprise_pkg }}"
-    checksum: sha256:{{ vault_sha256.stdout }}
+    checksum: "sha256:{{ (lookup('url', vault_checksum_file_url, wantlist=true) | select('search', vault_enterprise_pkg | regex_escape()) | first).split()[0] }}"
     timeout: 42
     mode: 0644
   become: false
   run_once: true
   tags: installation
-  when: not vault_package.stat.exists | bool
   delegate_to: 127.0.0.1
 
 - name: "[Enterprise] Unzip vault_enterprise_pkg (local)"
   unarchive:
     src: "{{ role_path }}/files/{{ vault_enterprise_pkg }}"
     dest: "{{ role_path }}/files/"
-    creates: "{{ role_path }}/files/vault"
+    # creates: "{{ role_path }}/files/vault"
   become: false
   run_once: true
   tags: installation
   delegate_to: 127.0.0.1
+  changed_when: false
 
 - name: "[Enterprise] Install version {{ vault_version }}"
   copy:
@@ -70,6 +61,7 @@
     mode: "0755"
   notify: Restart vault
   tags: installation
+  changed_when: false
 
 - name: "[Enterprise] Remove temporary vault installer files from role path"
   file:
@@ -79,3 +71,4 @@
   with_fileglob: "{{ role_path }}/files/vault"
   run_once: true
   tags: installation
+  changed_when: false

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -72,11 +72,11 @@
   become: true
   vars:
     _vault_repo_pkg: "{% if (ansible_pkg_mgr in ['yum', 'dnf']) %}\
-                  vault-{{ vault_version }}\
+                  vault{{ '-enterprise' if vault_enterprise else '' }}{{ '-hsm' if vault_enterprise_premium else '' }}-{{ vault_version }}\
                 {% elif (ansible_pkg_mgr == 'apt') %}\
-                  vault={{ vault_version }}\
+                  vault{{ '-enterprise' if vault_enterprise else '' }}{{ '-hsm' if vault_enterprise_premium else '' }}={{ vault_version }}-1\
                 {% else %}\
-                  vault={{ vault_version }}\
+                  vault{{ '-enterprise' if vault_enterprise else '' }}{{ '-hsm' if vault_enterprise_premium else '' }}={{ vault_version }}-1\
                 {% endif %}"
 
 - name: Mask default Vault config from package

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Modify version for enterprise installation
+  set_fact:
+    vault_version: "{{ vault_version }}+ent"
+  when: vault_enterprise
+
+- name: Modify version enterprise hsm installation
+  set_fact:
+    vault_version: "{{ vault_version }}+ent.hsm"
+  when: vault_enterprise_premium_hsm
+
 - name: Include asserts
   include_tasks: asserts.yml
 
@@ -57,14 +67,13 @@
   include_tasks: install_enterprise.yml
   when:
     - vault_enterprise | bool
+    - not vault_install_hashi_repo | bool
     - not vault_install_remotely | bool
-    - not vault_install_remote_repo | bool
     - installation_required | bool
 
 - name: Install OS packages and Vault via control host
   include_tasks: install.yml
   when:
-    - not vault_enterprise | bool
     - not vault_install_remotely | bool
     - not vault_install_hashi_repo | bool
     - installation_required | bool
@@ -72,7 +81,6 @@
 - name: Install Vault via HashiCorp repository
   include_tasks: install_hashi_repo.yml
   when:
-    - not vault_enterprise | bool
     - not vault_install_remotely | bool
     - vault_install_hashi_repo | bool
     - installation_required | bool
@@ -404,6 +412,7 @@
         VAULT_CACERT: "{{ lookup('env', 'VAULT_CACERT') |
                        default(vault_tls_config_path ~ '/' ~ vault_tls_ca_file if not (vault_tls_disable) else '', true) }}"
         VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') | default(lookup('file', '~/.vault-token', errors='ignore'), true) }}"
+  when: vault_plugin_install | bool
 
 - name: Vault status
   debug:


### PR DESCRIPTION
Hashicorp renamed its enterprise pkgs to `+ent.hsm` and `+ent` (https://releases.hashicorp.com/vault/)

this PR adjusts the role accordingly

Furthermore:
	* actually download the checksum file from hashicorp CDN
	* allow enterprise installation via apt or dnf repo
 	* update README.md
	* bump default vault version to `1.8.4`