### PR TITLE
Add vars to configure the URL of the apt repo and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ The role defines variables in `defaults/main.yml`:
 ### `vault_install_hashi_repo`
 
 - Set this to `true` when installing Vault via HashiCorp Linux repository.
-  When set, you can also define `vault_hashicorp_key_url` to override the
-  default URL of the GPG key loaded in apt keyring.
+  When set, you can also define `vault_hashicorp_key_url` and `vault_hashicorp_apt_repository_url`
+  to override the default URL of the GPG key loaded in apt keyring and the default URL of the apt
+  repository used.
 - Default value: *false*
 
 ### `vault_install_remotely`

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ The role defines variables in `defaults/main.yml`:
 
 ### `vault_install_hashi_repo`
 
-- Set this to `true` when installing Vault via HashiCorp Linux repository
+- Set this to `true` when installing Vault via HashiCorp Linux repository.
+  When set, you can also define `vault_hashicorp_key_url` to override the
+  default URL of the GPG key loaded in apt keyring.
 - Default value: *false*
 
 ### `vault_install_remotely`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,7 @@ vault_install_hashi_repo: false
 vault_install_remotely: false
 vault_privileged_install: false
 vault_hashicorp_key_url: "https://apt.releases.hashicorp.com/gpg"
+vault_hashicorp_apt_repository_url: "https://apt.releases.hashicorp.com"
 
 # Paths
 vault_bin_path: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ vault_start_pause_seconds: 0
 vault_install_hashi_repo: false
 vault_install_remotely: false
 vault_privileged_install: false
+vault_hashicorp_key_url: "https://apt.releases.hashicorp.com/gpg"
 
 # Paths
 vault_bin_path: /usr/local/bin

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -16,7 +16,7 @@
 
 - name: Add HashiCorp apt signing key
   apt_key:
-    url: https://apt.releases.hashicorp.com/gpg
+    url: "{{ vault_hashicorp_key_url }}"
     state: present
   when: ansible_pkg_mgr == 'apt'
 

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -22,7 +22,7 @@
 
 - name: Add HashiCorp apt Repo
   apt_repository:
-    repo: "deb https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    repo: "deb {{ vault_hashicorp_apt_repository_url }} {{ ansible_distribution_release }} main"
     state: present
   when: ansible_pkg_mgr == 'apt'
 


### PR DESCRIPTION
This change adds two new vars named `vault_hashicorp_key_url` and `vault_hashicorp_apt_repository_url`. The former allows to change the default URL of the GPG key added to apt keyring. The latter allows to change the default URL of the apt repository to use. This could be used to install Vault from an apt mirror in air-gapped environments.