### PR TITLE
Add a var to reload Vault instead of restarting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ The role defines variables in `defaults/main.yml`:
 - Should the playbook restart Vault service when needed
 - Default value: true
 
+### `vault_service_reload`
+
+- Should the playbook reload Vault service when the main config changes.
+- Default value: false
+
 ### `vault_start_pause_seconds`
 
 - Some installations may need some time between the first Vault start

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,7 @@ vault_exec_output: ''
 
 # Handlers
 vault_service_restart: true
+vault_service_reload: false
 
 # ---------------------------------------------------------------------------
 # Vault variables

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,5 +3,14 @@
 
 - name: Restart vault
   become: true
-  service: name='{{ vault_systemd_service_name }}' state=restarted
+  service:
+    name: '{{ vault_systemd_service_name }}'
+    state: restarted
   when: vault_service_restart | bool
+
+- name: Reload vault
+  become: true
+  service:
+    name: '{{ vault_systemd_service_name }}'
+    state: reloaded
+  when: vault_service_reload | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -163,7 +163,9 @@
     group: "{{ vault_group }}"
     mode: "0400"
     backup: "{{ vault_backup_config | default('false') | bool | lower }}"
-  notify: Restart vault
+  notify:
+    - Restart vault
+    - Reload vault
 
 - name: Vault awskms seal configuration
   become: true


### PR DESCRIPTION
Some config changes can be taken into account by Vault with a reload. As restarting it might trigger an unseal process (eg. when it's sealed with Shamir keys), it might be quite disruptive. As such, this change adds a `vault_service_reload` var to tell the role to reload Vault instead. This is intended to be mostly set from the cli using: `$ ansible-playbook ... -e vault_service_reload=true ...` whenever needed.