### PR TITLE
Use vault_api_addr to set VAULT_ADDR in .bashrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,16 +813,24 @@ available starting at Vault version 1.4.
 - Address to bind to for cluster server-to-server requests
 - Default value: `"{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"`
 
+### `vault_hostname`
+
+- Hostname used to define `vault_cluster_addr` and `vault_api_addr` (when set).
+- Default value: none
+
 ### `vault_cluster_addr`
 
 - Address to advertise to other Vault servers in the cluster for request forwarding
-- Default value: `"{{ vault_protocol }}://{{ vault_cluster_address }}"`
+- Default value: If `vault_hostname` is set, `{{ vault_protocol }}://{{ vault_hostname }}:{{ vault_port + 1 }}`. Otherwise, `{{ vault_protocol }}://{{ vault_cluster_address }}`
 
 ### `vault_api_addr`
 
 - [HA Client Redirect address](https://www.vaultproject.io/docs/concepts/ha.html#client-redirection)
-- Default value: `"{{ vault_protocol }}://{{ vault_redirect_address or hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"`
-  - vault_redirect_address is kept for backward compatibility but is deprecated.
+- Default value:
+  - If `vault_hostname` is set, `{{ vault_protocol }}://{{ vault_hostname }}:{{ vault_port }}`.
+  - If `vault_redirect_address` is set, `{{ vault_protocol }}://{{ vault_redirect_address }}:{{ vault_port }}`.
+  - Otherwise, `{{ vaul_protocol }}://{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"`
+  - `vault_redirect_address` is kept for backward compatibility but is deprecated.
 
 ### `vault_disable_api_health_check`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,7 @@ vault_service_reload: false
 # ---------------------------------------------------------------------------
 
 vault_group_name: vault_instances
+vault_hostname: ""
 vault_cluster_name: dc1
 vault_datacenter: dc1
 vault_log_level: "{{ lookup('env','VAULT_LOG_LEVEL') | default('info', true) }}"
@@ -121,8 +122,9 @@ vault_backend_gcs: vault_backend_gcs.j2
 
 vault_cluster_disable: false
 vault_cluster_address: "{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"
-vault_cluster_addr: "{{ vault_protocol }}://{{ vault_cluster_address }}"
-vault_api_addr: "{{ vault_protocol }}://{{ vault_redirect_address | default(hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address']) }}:{{ vault_port }}"
+vault_cluster_addr: "{{ vault_protocol }}://{% if vault_hostname %}{{ vault_hostname }}:{{ (vault_port | int) + 1 }}{% else %}{{ vault_cluster_address }}{% endif %}"
+vault_api_addr: |-2
+  {{ vault_protocol }}://{{ vault_hostname | default(vault_redirect_address, true) | default(hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address']) }}:{{ vault_port }}
 vault_disable_api_health_check: false
 
 vault_max_lease_ttl: "768h"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -309,10 +309,6 @@
 - name: Restart Vault if needed
   meta: flush_handlers
 
-- name: Compute TLS friendly vault_addr
-  set_fact:
-    vault_addr: "{{ (vault_address == '0.0.0.0') | ternary('127.0.0.1', vault_address) }}"
-
 - name: Insert http(s) export in dotfile
   become: true
   lineinfile:
@@ -345,8 +341,6 @@
 # This should succeed regardless of seal state
 - name: Vault API reachable?
   # Attempt to help with long lines > 160 issues
-  vars:
-    vault_addr_protocol: "{{ vault_tls_disable | ternary('http', 'https') }}"
   environment:
     no_proxy: "{{ vault_address }}"
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -318,7 +318,7 @@
   lineinfile:
     path: "{{ vault_home }}/{{ vault_dotfile }}"
     regexp: "^export VAULT_ADDR="
-    line: "export VAULT_ADDR='{{ vault_tls_disable | ternary('http', 'https') }}://{{ vault_addr }}:{{ vault_port }}'"
+    line: "export VAULT_ADDR='{{ vault_api_addr }}'"
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
     create: true


### PR DESCRIPTION
Prior to this PR, `vault_api_addr` and `vault_cluster_addr` were defined using the IPv4 address of the default interface of the host. Moreover, a variable named `vault_hostname` was used to run the reachability check but was undocumented.

This change documents `vault_hostname` and leverages it to set the value of `vault_api_addr` and `vault_cluster_addr` when it's available. Otherwise, these vars are defined as before.

Moreover, `vault_api_addr` is now used to set the URL used by the reachability check and to set the value of `VAULT_ADDR` in .bashrc. Before that change, these URLs were define by concatenating the value of `vault_addr` and `vault_port` together. `vault_addr` was defined as being either `127.0.0.1` (when `vault_address` was `0.0.0.0`) or the value of `vault_address`. However, `vault_address` is used to define the IP address Vault should bind to. Although, by default, they were defined to be exactly the same as `vault_api_addr` default value, when overriding that param (for instance to put an hostname instead of the IP address), the value of `VAULT_ADDR` (and the URL used by the reachability check) could be wrong in some cases (eg. when using TLS certs with no `IP: 127.0.0.1` SAN). Instead of adding a new var to override the value of `VAULT_ADDR`, this change reuses the value of `vault_api_addr`, which is now defined through `vault_hostname` param (when provided).