### PR TITLE
Add vault_harden_file_perms to set chmod 0550 on config/plugins path

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ The role defines variables in `defaults/main.yml`:
 - PID file location
 - Default value: `/var/run/vault`
 
+### `vault_harden_file_perms`
+
+- Whether this role should disallow Vault from writing into config and plugin
+  path. This should be enabled to follow [Production Hardening](https://learn.hashicorp.com/tutorials/vault/production-hardening).
+- Default value: false
+
 ### `vault_manage_user`
 
 - Should this role manage the vault user?

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ vault_data_path: /var/vault
 vault_log_path: /var/log/vault
 vault_run_path: /var/run/vault
 vault_home: "/home/{{ vault_user }}"
+vault_harden_file_perms: true
 
 # System user and group
 vault_manage_user: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,17 +104,22 @@
 - name: Create directories
   become: true
   file:
-    dest: "{{ item }}"
+    dest: "{{ item.path }}"
     state: directory
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
-    mode: 0750
+    mode: "{{ item.mode }}"
   with_items:
-    - "{{ vault_config_path }}"
-    - "{{ vault_plugin_path }}"
-    - "{{ vault_data_path }}"
-    - "{{ vault_log_path }}"
-    - "{{ vault_run_path }}"
+    - path: "{{ vault_config_path }}"
+      mode: "{{ vault_harden_file_perms | ternary('0550', '0750') }}"
+    - path: "{{ vault_plugin_path }}"
+      mode: "{{ vault_harden_file_perms | ternary('0550', '0750') }}"
+    - path: "{{ vault_data_path }}"
+      mode: "0750"
+    - path: "{{ vault_log_path }}"
+      mode: "0750"
+    - path: "{{ vault_run_path }}"
+      mode: "0750"
 
 - name: Enable logrotate for vault
   become: true


### PR DESCRIPTION
The [Production Hardening](https://learn.hashicorp.com/tutorials/vault/production-hardening) have a bullet point "Allow minimal write privileges". It states: "its executable binary or any Vault configuration files".

Prior to this change, the config and plugins path had chmod 0750, so Vault could actually write config files and change plugins.

This commit adds a new parameter named vault_harden_file_perms (turned off by default). When enabled, it changes the chmod of config and plugins path to 0550 to effectively disallow Vault from writing into these dirs.

Side note: I hesitate between adding a new parameter and just setting chmod to 0550 and offering no way to configure that. The latter case is better because it's more secure but, although unlikely, I think it might break existing installation. I can update my PR if you think a new parameter is unnecessary.