### PR TITLE
vault api health check via the actual vault api address

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,11 @@ available starting at Vault version 1.4.
 - Default value: `"{{ vault_protocol }}://{{ vault_redirect_address or hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"`
   - vault_redirect_address is kept for backward compatibility but is deprecated.
 
+### `vault_disable_api_health_check`
+
+- flag for disabling the health check on vaults api address
+- Default value: `false`
+
 ### `vault_cluster_disable`
 
 - Disable HA clustering

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -123,6 +123,7 @@ vault_cluster_disable: false
 vault_cluster_address: "{{ hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ (vault_port | int) + 1}}"
 vault_cluster_addr: "{{ vault_protocol }}://{{ vault_cluster_address }}"
 vault_api_addr: "{{ vault_protocol }}://{{ vault_redirect_address | default(hostvars[inventory_hostname]['ansible_'+vault_iface]['ipv4']['address']) }}:{{ vault_port }}"
+vault_disable_api_health_check: false
 
 vault_max_lease_ttl: "768h"
 vault_default_lease_ttl: "768h"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -351,7 +351,7 @@
     no_proxy: "{{ vault_address }}"
   uri:
     validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
-    url: "{{ vault_addr_protocol }}://{{ vault_hostname | default(vault_addr, true) }}:{{ vault_port }}/v1/sys/health"
+    url: "{{ vault_api_addr }}/v1/sys/health"
     method: GET
     # 200 if initialized, unsealed, and active
     # 429 if unsealed and standby
@@ -369,9 +369,13 @@
   changed_when: false
   tags:
     - check_vault
+  when:
+    - not vault_disable_api_health_check | bool
 
 - name: Vault status
   debug:
     msg: "Vault is {{ vault_http_status[check_result.status|string] }}"
   tags:
     - check_vault
+  when:
+    - not vault_disable_api_health_check | bool


### PR DESCRIPTION
After deploying vault a health check is running towards all vault nodes via their respective hostnames and ports:

```yaml
- name: Vault API reachable?
  # Attempt to help with long lines > 160 issues
  vars:
    vault_addr_protocol: "{{ vault_tls_disable | ternary('http', 'https') }}"
  environment:
    no_proxy: "{{ vault_address }}"
uri:
    validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
    url: "{{ vault_addr_protocol }}://{{ vault_hostname | default(vault_addr, true) }}:{{ vault_port }}/v1/sys/health"
    method: GET
```

However, in enterprise environments it is common that the vault nodes are only accessible via a bastion host or jumphost and the vault API  is served through a frontfacing loadbalaner. Thus the task "Vault API reachable?" failed for me.

This PR changes the health check to `vault_api_addr` and additionally introduces a boolean flag `vault_disable_api_health_check` allowing the user to disable the final task in order to prevent the playbook from failing, if that is the case.

Let me know what you think :) 

Kind regards
