### PR TITLE
Remove unused vault_group_name var

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,6 @@ The role defines variables in `defaults/main.yml`:
 - Should this role manage the vault group?
 - Default value: false
 
-### `vault_group_name`
-
-- Inventory group name
-- Default value: vault_instances
-
 ### `vault_cluster_name`
 
 - Cluster name label

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,7 +65,6 @@ vault_service_reload: false
 # Vault variables
 # ---------------------------------------------------------------------------
 
-vault_group_name: vault_instances
 vault_cluster_name: dc1
 vault_datacenter: dc1
 vault_log_level: "{{ lookup('env','VAULT_LOG_LEVEL') | default('info', true) }}"


### PR DESCRIPTION
Although this variable exists since the first ever commit, it's never
been used.