### PR TITLE
Feature/allow static raft cluster members

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,23 @@ vault_tcp_listeners:
 - Inventory group name of servers hosting the raft backend
 - Default value: vault_raft_servers
 
+### `vault_raft_cluster_members`
+
+- Members of the raft cluster
+- Default value: hosts in `vault_raft_group_name` group
+- Can be used to override the behaviour of dynamically selecting all hosts in `vault_raft_group_name`
+- Example:
+  ```
+  vault_raft_cluster_members:
+    - peer: vault-host-1
+      api_addr: https://vault-host-1:8200
+    - peer: vault-host-2
+      api_addr: https://vault-host-2:8200
+    - peer: vault-host-3
+      api_addr: https://vault-host-2:8200
+  ```
+- Setting the `vault_raft_cluster_members` statically enables you to run the role against a single host (instead of the entire host group)
+
 #### `vault_raft_data_path`
 
 - Data path for Raft

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -203,11 +203,12 @@ vault_gcs_credentials_dst_file: "{{ vault_home }}/{{ vault_gcs_credentials_src_f
 vault_backend: raft
 vault_raft_group_name: "vault_raft_servers"
 vault_raft_cluster_members: |
-  {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
-  - {{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}
+  {% for server in groups[vault_raft_group_name] %}
+  - peer: {{ server }}
+    url: {{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}
   {% endfor %}
 
-  vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"
+vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"
 vault_raft_node_id: "{{ lookup('env', 'VAULT_RAFT_NODE_ID') | default(inventory_hostname_short, true) }}"
 # vault_raft_leader_tls_servername
 # vault_raft_performance_multiplier:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -205,7 +205,7 @@ vault_raft_group_name: "vault_raft_servers"
 vault_raft_cluster_members: |
   {% for server in groups[vault_raft_group_name] %}
   - peer: {{ server }}
-    url: {{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}
+    api_addr: {{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}
   {% endfor %}
 
 vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -203,10 +203,14 @@ vault_gcs_credentials_dst_file: "{{ vault_home }}/{{ vault_gcs_credentials_src_f
 vault_backend: raft
 vault_raft_group_name: "vault_raft_servers"
 vault_raft_cluster_members: |
+  [
   {% for server in groups[vault_raft_group_name] %}
-  - peer: {{ server }}
-    api_addr: {{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}
+    {
+      "peer": "{{ server }}",
+      "api_addr": "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+    },
   {% endfor %}
+  ]
 
 vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"
 vault_raft_node_id: "{{ lookup('env', 'VAULT_RAFT_NODE_ID') | default(inventory_hostname_short, true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -202,7 +202,12 @@ vault_gcs_credentials_dst_file: "{{ vault_home }}/{{ vault_gcs_credentials_src_f
 # raft storage settings
 vault_backend: raft
 vault_raft_group_name: "vault_raft_servers"
-vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"
+vault_raft_cluster_members: |
+  {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
+  - {{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}
+  {% endfor %}
+
+  vault_raft_data_path: "{{ lookup('env', 'VAULT_RAFT_DATA_PATH') | default(vault_data_path, true) }}"
 vault_raft_node_id: "{{ lookup('env', 'VAULT_RAFT_NODE_ID') | default(inventory_hostname_short, true) }}"
 # vault_raft_leader_tls_servername
 # vault_raft_performance_multiplier:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -207,7 +207,8 @@ vault_raft_cluster_members: |
   {% for server in groups[vault_raft_group_name] %}
     {
       "peer": "{{ server }}",
-      "api_addr": "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+      "api_addr": "{{ hostvars[server]['vault_api_addr'] |
+      default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
     },
   {% endfor %}
   ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -348,7 +348,7 @@
   vars:
     vault_addr_protocol: "{{ vault_tls_disable | ternary('http', 'https') }}"
   environment:
-    no_proxy: "{{ vault_address }}"
+    no_proxy: "{{ vault_api_addr | urlsplit('hostname') }}"
   uri:
     validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
     url: "{{ vault_api_addr }}/v1/sys/health"

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -41,7 +41,7 @@ storage "raft" {
   }
     {% else %}
   retry_join {
-    leader_api_addr =  "{{ raft_peer }}"
+    leader_api_addr =  "{{ raft_peer.api_addr }}"
   }
     {% endif %}
   {% endfor %}

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -28,10 +28,10 @@ storage "raft" {
   }
   {% endif %}
   {% if not vault_raft_cloud_auto_join_exclusive %}
-  {% for raft_peer in vault_raft_cluster_members %}
+  {% for raft_peer in vault_raft_cluster_members | rejectattr('peer', 'equalto', inventory_hostname) %}
     {% if not (vault_tls_disable | bool) %}
   retry_join {
-    leader_api_addr = "{{ raft_peer }}"
+    leader_api_addr = "{{ raft_peer.api_addr }}"
     {% if vault_raft_leader_tls_servername is defined %}
     leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
     {% endif %}

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -28,10 +28,10 @@ storage "raft" {
   }
   {% endif %}
   {% if not vault_raft_cloud_auto_join_exclusive %}
-  {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
+  {% for raft_peer in vault_raft_cluster_members %}
     {% if not (vault_tls_disable | bool) %}
   retry_join {
-    leader_api_addr = "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+    leader_api_addr = "{{ raft_peer }}"
     {% if vault_raft_leader_tls_servername is defined %}
     leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
     {% endif %}
@@ -41,7 +41,7 @@ storage "raft" {
   }
     {% else %}
   retry_join {
-    leader_api_addr =  "http://{{ hostvars[server]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"
+    leader_api_addr =  "{{ raft_peer }}"
   }
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
# Add feature to allow the manual configuration of Raft Cluster Members

## What?
Allows the static definition of members of the Raft cluster using the `vault_raft_cluster_members` variable.

e.g. 
  ```
  vault_raft_cluster_members:
    - peer: vault-host-1
      api_addr: https://vault-host-1:8200
    - peer: vault-host-2
      api_addr: https://vault-host-2:8200
    - peer: vault-host-3
      api_addr: https://vault-host-2:8200
  ```

Note: This variable defaults to the selecting hosts using the automatic method of selecting all hosts in the `vault_raft_group_name` group

Note: Also fixes setting `no_proxy` environment variable for API reachable check

## Why?
Currently Raft cluster membership is controlled using `vault_raft_group_name` which will dynamically select hosts that are members of the `vault_raft_group_name` group. This means, however, that the role must be run against all the hosts of a cluster at once.

The ability to run the role against single members of the cluster is important for staged rollout etc.
