### PR TITLE
feat(seal): add support for ocikms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,41 @@ This Auto-unseal mechanism is Open Source in Vault 1.0 but would require Enterpr
 - The CryptoKey's name. A CryptoKey's name must be unique within a location and match the regular expression [a-zA-Z0-9_-]{1,63}
 - Default value: vault_key
 
+## Vault OCI KMS Auto-unseal
+
+This feature enabled operators to delegate the unsealing process to OCI KMS to ease operations in the event of a partial failure and to
+aid in the creation of new or ephemeral clusters.
+
+### `vault_ocikms`
+
+- Set to true to enable OCI KMS Auto-unseal.
+- Default value: false
+
+### `vault_ocikms_backend`
+
+- Backend seal template filename.
+- Default value: `vault_seal_ocikms.j2`
+
+### `vault_ocikms_auth_type_api_key`
+
+- Specifies if using API key to authenticate to OCI KMS service.
+- Default value: false
+
+### `vault_ocikms_key_id`
+
+- The OCI KMS key ID to use.
+- Default value: VAULT_OCIKMS_SEAL_KEY_ID
+
+### `vault_ocikms_crypto_endpoint`
+
+- The OCI KMS cryptographic endpoint (or data plane endpoint) to be used to make OCI KMS encryption/decryption requests.
+- Default value: VAULT_OCIKMS_CRYPTO_ENDPOINT
+
+### `vault_ocikms_management_endpoint`
+
+- The OCI KMS management endpoint (or control plane endpoint) to be used to make OCI KMS key management requests.
+- Default value: VAULT_OCIKMS_MANAGEMENT_ENDPOINT
+
 ## Vault Transit Auto-unseal
 This enables Vault to use another Vault instance for the unseal process using its transit secret engine
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -344,6 +344,14 @@ vault_gkms_region: 'global'
 vault_gkms_key_ring: 'vault'
 vault_gkms_crypto_key: 'vault_key'
 
+# ocikms seal
+vault_ocikms: false
+vault_ocikms_backend: vault_seal_ocikms.j2
+vault_ocikms_auth_type_api_key: false
+vault_ocikms_key_id: "{{ lookup('env','VAULT_OCIKMS_SEAL_KEY_ID') | default('', false) }}"
+vault_ocikms_crypto_endpoint: "{{ lookup('env','VAULT_OCIKMS_CRYPTO_ENDPOINT') | default('', false) }}"
+vault_ocikms_management_endpoint: "{{ lookup('env','VAULT_OCIKMS_MANAGEMENT_ENDPOINT') | default('', false) }}"
+
 # pkcs11 seal
 vault_enterprise_premium_hsm: false
 # WARNING: the following variable is deprecated as this section will become

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -110,6 +110,10 @@ ui = {{ vault_ui | bool | lower }}
   {% include vault_backend_gkms with context %}
 {% endif %}
 
+{% if vault_ocikms | bool -%}
+  {% include vault_ocikms_backend with context %}
+{% endif %}
+
 {% if vault_telemetry_enabled | bool -%}
 telemetry {
   {% if vault_statsite_address is defined %}

--- a/templates/vault_seal_ocikms.j2
+++ b/templates/vault_seal_ocikms.j2
@@ -1,0 +1,10 @@
+seal "ocikms" {
+  key_id = "{{ vault_ocikms_key_id }}"
+  auth_type_api_key = "{{ vault_ocikms_auth_type_api_key }}"
+{% if vault_ocikms_crypto_endpoint is string and vault_ocikms_crypto_endpoint|length %}
+  crypto_endpoint = "{{ vault_ocikms_crypto_endpoint }}"
+{% endif %}
+{% if vault_ocikms_management_endpoint is string and vault_ocikms_management_endpoint|length %}
+  management_endpoint = "{{ vault_ocikms_management_endpoint }}"
+{% endif %}
+}


### PR DESCRIPTION
This pull request adds support for Oracle Cloud KMS Auto-unseal feature. It has been successfully tested on OCI platform.

The minimum variables needed to configure for testing are:

- vault_ocikms: true
- vault_ocikms_key_id: '[key_id](https://www.vaultproject.io/docs/configuration/seal/ocikms#key_id)'
- vault_ocikms_crypto_endpoint: '[crypto_endpoint](https://www.vaultproject.io/docs/configuration/seal/ocikms#crypto_endpoint)'
- vault_ocikms_management_endpoint: '[management_endpoint](https://www.vaultproject.io/docs/configuration/seal/ocikms#management_endpoint)'

The official docs have additional instructions: https://www.vaultproject.io/docs/configuration/seal/ocikms

Config example:
```yaml
vault_ocikms: true
vault_ocikms_auth_type_api_key: false
vault_ocikms_key_id: ocid1.key.oc1.sa-saopaulo-1.example
vault_ocikms_crypto_endpoint: https://example-crypto.kms.sa-saopaulo-1.oraclecloud.com
vault_ocikms_management_endpoint: https://example-management.kms.sa-saopaulo-1.oraclecloud.com
```

The dedicated  config template step has been replaced by the include block because by default, only the main configuration file (vault_main.hcl) is used, otherwise it would be necessary to set the vault_use_config_path variable to load this seal config.

Further details also added to README.md

Regards,