### PR TITLE
templates: backend raft: resolve to proper interface 

### DIFF
--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -31,7 +31,7 @@ storage "raft" {
   {% for server in groups[vault_raft_group_name] | difference([inventory_hostname]) %}
     {% if not (vault_tls_disable | bool) %}
   retry_join {
-    leader_api_addr = "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+    leader_api_addr = "{{ hostvars[server]['vault_api_addr'] | default(vault_protocol + '://' + hostvars[server]['ansible_facts'][hostvars[server]['vault_iface'] | default(vault_iface)]['ipv4']['address'] + ':' + (vault_port|string)) }}"
     {% if vault_raft_leader_tls_servername is defined %}
     leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
     {% endif %}
@@ -41,7 +41,7 @@ storage "raft" {
   }
     {% else %}
   retry_join {
-    leader_api_addr =  "http://{{ hostvars[server]['ansible_'+vault_iface]['ipv4']['address'] }}:{{ vault_port }}"
+    leader_api_addr =  "http://{{ hostvars[server]['ansible_facts'][hostvars[server]['vault_iface'] | default(vault_iface)]['ipv4']['address'] }}:{{ vault_port }}"
   }
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
This `for` loop is looping through all (remaining) hosts from group - but it's using `vault_iface` value of current host. I believe that's part of the issue with #211

There's also another change - instead of `['ansible' + vault_iface]` hostvars key - I've switched it to `ansible_facts` instead - as that one seems to be (always?) available. I'm not sure if presence of `'ansible_' + vault_iface` hostvars dict depends on ansible version, but either way - I've tried it on a couple of setups/installations and it seems to be passing everywhere.

Thanks.