### PR TITLE
Allow overriding rpm repo url and support rhsm repo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ The role defines variables in `defaults/main.yml`:
 ### `vault_install_hashi_repo`
 
 - Set this to `true` when installing Vault via HashiCorp Linux repository.
-  When set, you can also define `vault_hashicorp_key_url` and `vault_hashicorp_apt_repository_url`
-  to override the default URL of the GPG key loaded in apt keyring and the default URL of the apt
+  When set, you can also define `vault_repository_key_url` and `vault_repository_url`
+  to override the default URL of the GPG key for the repository and the default URL of the
   repository used.
 - Default value: *false*
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ The role defines variables in `defaults/main.yml`:
   repository used.
 - Default value: *false*
 
+### `vault_install_rhsm_repo`
+
+- Set this to `true` when installing Vault via a RHSM repository (RedHat Satellite/Foreman/etc.).
+  When set, you need to define the rhsm repo name with `vault_rhsm_repo_name` and optionally also the
+  rhsm subscription name with `vault_rhsm_subscription_name`.
+- Default value: *false*
+
 ### `vault_install_remotely`
 
 - Set this to `true` will download Vault binary from each target instead of localhost

--- a/README.md
+++ b/README.md
@@ -120,12 +120,21 @@ The role defines variables in `defaults/main.yml`:
   repository used.
 - Default value: *false*
 
-### `vault_install_rhsm_repo`
+### `vault_rhsm_repo_name`
 
-- Set this to `true` when installing Vault via a RHSM repository (RedHat Satellite/Foreman/etc.).
-  When set, you need to define the rhsm repo name with `vault_rhsm_repo_name` and optionally also the
-  rhsm subscription name with `vault_rhsm_subscription_name`.
-- Default value: *false*
+- Name of rhsm repo
+- Set this to the name of your rhsm repo when installing Vault via a RHSM repository (RedHat Satellite/Foreman/etc.).
+  When set, you need make sure `vault_install_hashi_repo` is set to `true` to enable repo install. And optionally also
+  the rhsm subscription name with `vault_rhsm_subscription_name`.
+- Default value: null
+
+### `vault_rhsm_subscription_name`
+
+- Name of rhsm subscription
+- Set the rhsm subscription name to attach the rhsm subscription via subscription-manager.
+  When set, you need make sure `vault_install_hashi_repo` is set to `true` to enable repo install. And also that
+  `vault_rhsm_repo_name` is set.
+- Default value: null
 
 ### `vault_install_remotely`
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The role defines variables in `defaults/main.yml`:
   repository used.
 - Default value: *false*
 
-### `vault_rhsm_repo_name`
+### `vault_rhsm_repo_id`
 
 - Name of rhsm repo
 - Set this to the name of your rhsm repo when installing Vault via a RHSM repository (RedHat Satellite/Foreman/etc.).
@@ -133,7 +133,7 @@ The role defines variables in `defaults/main.yml`:
 - Name of rhsm subscription
 - Set the rhsm subscription name to attach the rhsm subscription via subscription-manager.
   When set, you need make sure `vault_install_hashi_repo` is set to `true` to enable repo install. And also that
-  `vault_rhsm_repo_name` is set.
+  `vault_rhsm_repo_id` is set.
 - Default value: null
 
 ### `vault_install_remotely`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,12 +29,11 @@ vault_start_pause_seconds: 0
 
 # Install method variables
 vault_install_hashi_repo: false
-vault_install_rhsm_repo: false
 vault_install_remotely: false
 vault_privileged_install: false
 
 # Paths
-vault_bin_path: "{{ '/usr/bin' if (vault_install_hashi_repo or vault_install_rhsm_repo) else '/usr/local/bin' }}"
+vault_bin_path: "{{ '/usr/bin' if (vault_install_hashi_repo) else '/usr/local/bin' }}"
 vault_config_path: /etc/vault.d
 vault_plugin_path: /usr/local/lib/vault/plugins
 vault_data_path: /var/vault

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,12 +21,15 @@ vault_zip_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{
 vault_checksum_file_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version}}_SHA256SUMS"
 vault_repository_url: "{{ _vault_repository_url | default() }}"
 vault_repository_key_url: "{{ _vault_repository_key_url | default() }}"
+vault_rhsm_subscription_name:
+vault_rhsm_repo_name:
 
 # Installation
 vault_start_pause_seconds: 0
 
 # Install method variables
 vault_install_hashi_repo: false
+vault_install_rhsm_repo: false
 vault_install_remotely: false
 vault_privileged_install: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,8 @@ vault_pkg: "vault_{{ vault_version }}_{{ vault_os }}_{{ vault_architecture }}.zi
 vault_shasums: "vault_{{ vault_version }}_SHA256SUMS"
 vault_zip_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version }}_{{ vault_os }}_{{ vault_architecture }}.zip"
 vault_checksum_file_url: "https://releases.hashicorp.com/vault/{{ vault_version }}/vault_{{ vault_version}}_SHA256SUMS"
+vault_repository_url: "{{ _vault_repository_url | default() }}"
+vault_repository_key_url: "{{ _vault_repository_key_url | default() }}"
 
 # Installation
 vault_start_pause_seconds: 0
@@ -27,10 +29,6 @@ vault_start_pause_seconds: 0
 vault_install_hashi_repo: false
 vault_install_remotely: false
 vault_privileged_install: false
-#vault_hashicorp_key_url: "https://apt.releases.hashicorp.com/gpg"
-vault_repository_url: "{{ _vault_repository_url | default() }}"
-vault_repository_key_url: "{{ _vault_repository_key_url | default() }}"
-#vault_hashicorp_apt_repository_url: "https://apt.releases.hashicorp.com"
 
 # Paths
 vault_bin_path: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ vault_checksum_file_url: "https://releases.hashicorp.com/vault/{{ vault_version 
 vault_repository_url: "{{ _vault_repository_url | default() }}"
 vault_repository_key_url: "{{ _vault_repository_key_url | default() }}"
 vault_rhsm_subscription_name:
-vault_rhsm_repo_name:
+vault_rhsm_repo_id:
 
 # Installation
 vault_start_pause_seconds: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,8 +27,10 @@ vault_start_pause_seconds: 0
 vault_install_hashi_repo: false
 vault_install_remotely: false
 vault_privileged_install: false
-vault_hashicorp_key_url: "https://apt.releases.hashicorp.com/gpg"
-vault_hashicorp_apt_repository_url: "https://apt.releases.hashicorp.com"
+#vault_hashicorp_key_url: "https://apt.releases.hashicorp.com/gpg"
+vault_repository_url: "{{ _vault_repository_url | default() }}"
+vault_repository_key_url: "{{ _vault_repository_key_url | default() }}"
+#vault_hashicorp_apt_repository_url: "https://apt.releases.hashicorp.com"
 
 # Paths
 vault_bin_path: /usr/local/bin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,14 +43,14 @@ vault_home: "/home/{{ vault_user }}"
 vault_harden_file_perms: true
 
 # System user and group
-vault_manage_user: true
+vault_manage_user: "{{ false if (vault_install_hashi_repo) else true }}"
 vault_user: vault
 vault_manage_group: false
 vault_group: bin
 vault_groups: null
 
 vault_dotfile: ".bashrc"
-vault_dotfile_disable: false
+vault_dotfile_disable: "{{ true if (vault_install_hashi_repo) else false }}"
 
 # Logging
 vault_enable_log: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,7 +36,7 @@ vault_privileged_install: false
 vault_bin_path: "{{ '/usr/bin' if (vault_install_hashi_repo) else '/usr/local/bin' }}"
 vault_config_path: /etc/vault.d
 vault_plugin_path: /usr/local/lib/vault/plugins
-vault_data_path: /var/vault
+vault_data_path: "{{ '/opt/vault/data' if (vault_install_hashi_repo) else '/var/vault' }}"
 vault_log_path: /var/log/vault
 vault_run_path: /var/run/vault
 vault_home: "/home/{{ vault_user }}"
@@ -266,16 +266,16 @@ vault_systemd_unit_path: /lib/systemd/system
 # self-signed certificates you might need to change the following to false
 validate_certs_during_api_reachable_check: true
 
-vault_tls_config_path: "{{ lookup('env','VAULT_TLS_DIR') | default('/etc/vault/tls', true) }}"
+vault_tls_config_path: "{{ lookup('env','VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
 vault_tls_src_files: "{{ lookup('env','VAULT_TLS_SRC_FILES') | default(role_path+'/files', true) }}"
 
 vault_tls_disable: "{{ lookup('env','VAULT_TLS_DISABLE') | default(1, true) }}"
 vault_tls_gossip: "{{ lookup('env','VAULT_TLS_GOSSIP') | default(0, true) }}"
 
-vault_tls_copy_keys: true
+vault_tls_copy_keys: "{{ false if (vault_install_hashi_repo) else true }}"
 vault_protocol: "{% if vault_tls_disable %}http{% else %}https{% endif %}"
-vault_tls_cert_file: "{{ lookup('env','VAULT_TLS_CERT_FILE') | default('server.crt', true) }}"
-vault_tls_key_file: "{{ lookup('env','VAULT_TLS_KEY_FILE') | default('server.key', true) }}"
+vault_tls_cert_file: "{{ lookup('env','VAULT_TLS_CERT_FILE') | default(('tls.crt' if (vault_install_hashi_repo) else 'server.crt'), true) }}"
+vault_tls_key_file: "{{ lookup('env','VAULT_TLS_KEY_FILE') | default(('tls.key' if (vault_install_hashi_repo) else 'server.key'), true) }}"
 vault_tls_ca_file: "{{ lookup('env','VAULT_TLS_CA_CRT') | default('ca.crt', true) }}"
 
 vault_tls_min_version: "{{ lookup('env','VAULT_TLS_MIN_VERSION') | default('tls12', true) }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ vault_harden_file_perms: true
 vault_manage_user: "{{ false if (vault_install_hashi_repo) else true }}"
 vault_user: vault
 vault_manage_group: false
-vault_group: bin
+vault_group: "{{ 'vault' if (vault_install_hashi_repo) else 'bin' }}"
 vault_groups: null
 
 vault_dotfile: ".bashrc"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ vault_install_remotely: false
 vault_privileged_install: false
 
 # Paths
-vault_bin_path: /usr/local/bin
+vault_bin_path: "{{ '/usr/bin' if (vault_install_hashi_repo or vault_install_rhsm_repo) else '/usr/local/bin' }}"
 vault_config_path: /etc/vault.d
 vault_plugin_path: /usr/local/lib/vault/plugins
 vault_data_path: /var/vault

--- a/molecule/default/tests/test_vault.yml
+++ b/molecule/default/tests/test_vault.yml
@@ -13,9 +13,9 @@ user:
   vault:
     exists: true
     groups:
-      - bin
+      - vault
 group:
-  bin:
+  vault:
     exists: true
 process:
   vault:

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -1,7 +1,7 @@
 ---
 # File: tasks/install_hashi_repo.yml
 #       Install Vault via HashiCorp Linux repository
-
+---
 - name: Add Vault/Hashicorp rpm repo
   yum_repository:
     name: hashicorp
@@ -11,21 +11,59 @@
     gpgcheck: true
     enabled: true
   become: true
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when:
+    - ansible_pkg_mgr in ['yum', 'dnf']
+    - not vault_install_rhsm_repo
 
 - name: Add Vault/Hashicorp apt key
-  become: true
   apt_key:
     url: "{{ vault_repository_key_url }}"
     state: present
+  become: true
   when: ansible_pkg_mgr == 'apt'
 
 - name: Add Vault/Hashicorp apt repo
-  become: true
   apt_repository:
     repo: "deb {{ vault_repository_url }} {{ ansible_distribution_release }} main"
     state: present
+  become: true
   when: ansible_pkg_mgr == 'apt'
+
+- name: Attach RHSM subscription / repo
+  when: (vault_install_rhsm_repo)
+  become: true
+  block:
+    - name: Check if Hashicorp/Vault RHSM repo subscription is enabled
+      command:
+        cmd: "subscription-manager list --consumed --matches={{ vault_rhsm_subscription_name | quote }} --pool-only"
+      register: _subscription_manager_consumed
+      changed_when: false
+      when: (vault_rhsm_subscription_name)
+
+    - name: Find Hashicorp/Vault RHSM repo subscription pool id
+      command:
+        cmd: "subscription-manager list --available --matches={{ vault_rhsm_subscription_name | quote }} --pool-only"
+      register: _subscription_manager_available
+      changed_when: false
+      when:
+        - (vault_rhsm_subscription_name)
+        - _subscription_manager_consumed.stdout | length <= 0
+
+    - name: Attach Hashicorp/Vault RHSM subscription
+      command:
+        cmd: "subscription-manager attach --pool={{ _subscription_manager_available.stdout }}"
+      register: _subscription_manager_attach
+      changed_when: _subscription_manager_attach.stdout is search('Successfully attached a subscription')
+      failed_when: _subscription_manager_attach.stdout is search('could not be found')
+      when:
+        - (vault_rhsm_subscription_name)
+        - _subscription_manager_consumed.stdout | default() | length <= 0
+        - _subscription_manager_available.stdout | default() | length > 0
+
+    - name: Enable RHSM repository
+      rhsm_repository:
+        name: "{{ vault_rhsm_repo_name }}"
+        state: enabled
 
 - name: Install Vault package
   package:

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -2,37 +2,44 @@
 # File: tasks/install_hashi_repo.yml
 #       Install Vault via HashiCorp Linux repository
 
-- name: Add HashiCorp yum repo
-  command: yum-config-manager --add-repo=https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
-  args:
-    creates: /etc/yum.repos.d/hashicorp.repo
+- name: Add Vault/Hashicorp rpm repo
+  yum_repository:
+    name: hashicorp
+    description: Hashicorp Stable - $basearch
+    baseurl: "{{ vault_repository_url }}"
+    gpgkey: "{{ vault_repository_key_url }}"
+    gpgcheck: true
+    enabled: true
+  become: true
   when: ansible_pkg_mgr in ['yum', 'dnf']
 
-- name: Install Vault via yum/dnf
-  yum:
-    name: "vault-{{ vault_version }}"
-    state: present
-  when: ansible_pkg_mgr in ['yum', 'dnf']
-
-- name: Add HashiCorp apt signing key
+- name: Add Vault/Hashicorp apt key
   become: true
   apt_key:
-    url: "{{ vault_hashicorp_key_url }}"
+    url: "{{ vault_repository_key_url }}"
     state: present
   when: ansible_pkg_mgr == 'apt'
 
-- name: Add HashiCorp apt Repo
+- name: Add Vault/Hashicorp apt repo
   become: true
   apt_repository:
-    repo: "deb {{ vault_hashicorp_apt_repository_url }} {{ ansible_distribution_release }} main"
+    repo: "deb {{ vault_repository_url }} {{ ansible_distribution_release }} main"
     state: present
   when: ansible_pkg_mgr == 'apt'
 
-- name: Install Vault via apt
+- name: Install Vault package
+  package:
+    name: "{{ _vault_repo_pkg }}"
+    state: present
   become: true
-  apt:
-    name: vault={{ vault_version }}
-  when: ansible_pkg_mgr == 'apt'
+  vars:
+    _vault_repo_pkg: "{% if (ansible_pkg_mgr in ['yum', 'dnf']) %}\
+                  vault-{{ vault_version }}\
+                {% elif (ansible_pkg_mgr == 'apt') %}\
+                  vault={{ vault_version }}\
+                {% else %}\
+                  vault={{ vault_version }}\
+                {% endif %}"
 
 - name: Mask default Vault config from package
   become: true

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -1,7 +1,7 @@
 ---
 # File: tasks/install_hashi_repo.yml
 #       Install Vault via HashiCorp Linux repository
----
+
 - name: Add Vault/Hashicorp rpm repo
   yum_repository:
     name: hashicorp

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -13,7 +13,7 @@
   become: true
   when:
     - ansible_pkg_mgr in ['yum', 'dnf']
-    - not vault_install_rhsm_repo
+    - not vault_rhsm_repo_name
 
 - name: Add Vault/Hashicorp apt key
   apt_key:
@@ -30,7 +30,7 @@
   when: ansible_pkg_mgr == 'apt'
 
 - name: Attach RHSM subscription / repo
-  when: (vault_install_rhsm_repo)
+  when: (vault_rhsm_repo_name)
   become: true
   block:
     - name: Check if Hashicorp/Vault RHSM repo subscription is enabled

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -13,7 +13,7 @@
   become: true
   when:
     - ansible_pkg_mgr in ['yum', 'dnf']
-    - not vault_rhsm_repo_name
+    - not vault_rhsm_repo_id
 
 - name: Add Vault/Hashicorp apt key
   apt_key:
@@ -30,7 +30,7 @@
   when: ansible_pkg_mgr == 'apt'
 
 - name: Attach RHSM subscription / repo
-  when: (vault_rhsm_repo_name)
+  when: (vault_rhsm_repo_id)
   become: true
   block:
     - name: Check if Hashicorp/Vault RHSM repo subscription is enabled
@@ -62,7 +62,7 @@
 
     - name: Enable RHSM repository
       rhsm_repository:
-        name: "{{ vault_rhsm_repo_name }}"
+        name: "{{ vault_rhsm_repo_id }}"
         state: enabled
 
 - name: Install Vault package

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,6 @@
     - not vault_enterprise | bool
     - not vault_install_remotely | bool
     - not vault_install_hashi_repo | bool
-    - not vault_install_rhsm_repo | bool
     - installation_required | bool
 
 - name: Install Vault via HashiCorp repository
@@ -79,7 +78,7 @@
   when:
     - not vault_enterprise | bool
     - not vault_install_remotely | bool
-    - vault_install_hashi_repo | bool or vault_install_rhsm_repo | bool
+    - vault_install_hashi_repo | bool
     - installation_required | bool
 
 - name: Install OS packages and Vault via remote hosts
@@ -88,7 +87,6 @@
     - not vault_enterprise | bool
     - vault_install_remotely | bool
     - not vault_install_hashi_repo | bool
-    - not vault_install_rhsm_repo | bool
     - installation_required | bool
 
 - name: Check Vault mlock capability

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,7 @@
     - not vault_enterprise | bool
     - not vault_install_remotely | bool
     - not vault_install_hashi_repo | bool
+    - not vault_install_rhsm_repo | bool
     - installation_required | bool
 
 - name: Install Vault via HashiCorp repository
@@ -87,6 +88,7 @@
     - not vault_enterprise | bool
     - vault_install_remotely | bool
     - not vault_install_hashi_repo | bool
+    - not vault_install_rhsm_repo | bool
     - installation_required | bool
 
 - name: Check Vault mlock capability

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,7 @@
   when:
     - not vault_enterprise | bool
     - not vault_install_remotely | bool
-    - vault_install_hashi_repo | bool
+    - vault_install_hashi_repo | bool or vault_install_rhsm_repo | bool
     - installation_required | bool
 
 - name: Install OS packages and Vault via remote hosts

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,3 +5,6 @@ vault_os_packages:
   - git
   - unzip
   - acl
+
+_vault_repository_url: "https://apt.releases.hashicorp.com"
+_vault_repository_key_url: "{{ _vault_repository_url }}/gpg"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,8 +7,10 @@ vault_os_packages:
   - unzip
 
 _vault_repository_url: "{% if ( ansible_distribution | lower  == 'fedora') %}\
-      https://rpm.releases.hashicorp.com/fedora/hashicorp.repo\
+      https://rpm.releases.hashicorp.com/fedora/$releasever/$basearch/stable\
+    {% elif (ansible_distribution | lower  == 'amazon') %}\
+      https://rpm.releases.hashicorp.com/AmazonLinux/$releasever/$basearch/stable
     {% else %}\
-      https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo\
+      https://rpm.releases.hashicorp.com/RHEL/$releasever/$basearch/stable\
     {% endif %}"
 _vault_repository_key_url: "{{ _vault_repository_url | urlsplit('scheme') }}://{{ _vault_repository_url | urlsplit('netloc') }}/gpg"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,3 +5,10 @@ vault_os_packages:
   - libselinux-python
   - git
   - unzip
+
+_vault_repository_url: "{% if ( ansible_distribution | lower  == 'fedora') %}\
+      https://rpm.releases.hashicorp.com/fedora/hashicorp.repo\
+    {% else %}\
+      https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo\
+    {% endif %}"
+_vault_repository_key_url: "{{ _vault_repository_url | urlsplit('scheme') }}://{{ _vault_repository_url | urlsplit('netloc') }}/gpg"


### PR DESCRIPTION
- Allows overriding the repo url for rpm based distros too when previously only deb repos were supported (#259)
- Adds support for installing from RHSM repos (RedHat Satellite / Foreman / etc.)