### PR TITLE
Simplify package checksum verification

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,39 +21,6 @@
     - ansible_distribution == "Debian"
     - (ansible_distribution_version == 'buster/sid') or (ansible_distribution_version is version(8.5, '>'))
 
-- name: Check Vault package checksum file (local)
-  stat:
-    path: "{{ role_path }}/files/{{ vault_shasums }}"
-  become: false
-  run_once: true
-  register: vault_checksum
-  delegate_to: 127.0.0.1
-
-- name: Get Vault package checksum file (local)
-  get_url:
-    url: "{{ vault_checksum_file_url }}"
-    dest: "{{ role_path }}/files/{{ vault_shasums }}"
-  become: "{{ vault_privileged_install }}"
-  run_once: true
-  tags: installation
-  when: not vault_checksum.stat.exists | bool
-  delegate_to: 127.0.0.1
-
-- name: Get Vault package checksum (local)
-  shell: |
-    set -o pipefail
-    grep "{{ vault_pkg }}" "{{ role_path }}/files/{{ vault_shasums }}" | \
-    awk '{print $1}'
-  args:
-    executable: /bin/bash
-  become: false
-  run_once: true
-  register: vault_sha256
-  tags:
-    - installation
-    - skip_ansible_lint
-  delegate_to: 127.0.0.1
-
 - name: Check Vault package file (local)
   stat:
     path: "{{ role_path }}/files/{{ vault_pkg }}"
@@ -66,7 +33,7 @@
   get_url:
     url: "{{ vault_zip_url }}"
     dest: "{{ role_path }}/files/{{ vault_pkg }}"
-    checksum: "sha256:{{ vault_sha256.stdout }}"
+    checksum: "sha256:{{ (lookup('url', vault_checksum_file_url, wantlist=true) | select('match', '.*' + vault_pkg + '$') | first).split()[0] }}"
     timeout: "42"
   become: "{{ vault_privileged_install }}"
   run_once: true

--- a/tasks/install_remote.yml
+++ b/tasks/install_remote.yml
@@ -16,25 +16,6 @@
     state: directory
     mode: 0750
 
-- name: Check Vault package checksum file
-  stat:
-    path: "/tmp/vault/{{ vault_shasums }}"
-  register: vault_checksum
-
-- name: Get Vault package checksum file
-  get_url:
-    url: "{{ vault_checksum_file_url }}"
-    dest: "/tmp/vault/{{ vault_shasums }}"
-  tags: installation
-  when: not vault_checksum.stat.exists | bool
-
-- name: Get Vault package checksum
-  shell: "grep {{ vault_pkg }} /tmp/vault/{{ vault_shasums }}"
-  register: vault_sha256
-  tags:
-    - installation
-    - skip_ansible_lint
-
 - name: Check Vault package file
   stat:
     path: "/tmp/vault/{{ vault_pkg }}"
@@ -45,7 +26,7 @@
   get_url:
     url: "{{ vault_zip_url }}"
     dest: "/tmp/vault/{{ vault_pkg }}"
-    checksum: "sha256:{{ vault_sha256.stdout.split(' ')|first }}"
+    checksum: "sha256:{{ (lookup('url', vault_checksum_file_url, wantlist=true) | select('match', '.*' + vault_pkg + '$') | first).split()[0] }}"
     timeout: "42"
   tags: installation
   when: not vault_package.stat.exists | bool


### PR DESCRIPTION
There's no need for get_url/shell/stat/etc. tasks when you can simply use a url lookup for fetching the package checksum.