### PR TITLE
support using already installed system certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 - Add support for proxy configuration
+- Add support for system certificates with `vault_tls_certs_path` and `vault_tls_private_path`
 
 ## v2.5.3
 - Add Prometheus telemetry support (thanks @bbayszczak)

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ vault_tcp_listeners:
     # vault_proxy_protocol_behavior: '{{ vault_proxy_protocol_behavior }}'
     # vault_proxy_protocol_authorized_addrs: '{{ vault_proxy_protocol_authorized_addrs }}'
     vault_tls_disable: '{{ vault_tls_disable }}'
-    vault_tls_config_path: '{{ vault_tls_config_path }}'
+    vault_tls_certs_path: '{{ vault_tls_certs_path }}'
+    vault_tls_private_path: '{{ vault_tls_private_path }}'
     vault_tls_cert_file: '{{ vault_tls_cert_file }}'
     vault_tls_key_file: '{{ vault_tls_key_file }}'
     vault_tls_ca_file: '{{ vault_tls_ca_file }}'
@@ -310,10 +311,15 @@ vault_tcp_listeners:
 - User-specified source directory for TLS files for storage communication
 - {{ vault_tls_src_files }}
 
-### `vault_backend_tls_config_path`
+### `vault_backend_tls_certs_path`
 
-- Path to directory containing backend tls config files
-- {{ vault_tls_config_path }}
+- Path to directory containing backend tls certificate files
+- {{ vault_tls_certs_path }}
+
+### `vault_backend_tls_private_path`
+
+- Path to directory containing backend tls key files
+- {{ vault_tls_private_path }}
 
 ### `vault_backend_tls_cert_file`
 
@@ -740,10 +746,15 @@ starting at Vault version 1.4.
 - ACL token for registering with Consul service registration
 - Default value: none
 
-#### `vault_service_registration_consul_tls_config_path`
+#### `vault_service_registration_consul_tls_certs_path`
 
-- Path to TLS certificate and key
-- Default value `{{ vault_tls_config_path }}`
+- path to tls certificate
+- default value `{{ vault_tls_certs_path }}`
+
+#### `vault_service_registration_consul_tls_private_path`
+
+- path to tls key
+- default value `{{ vault_tls_private_path }}`
 
 #### `vault_service_registration_consul_tls_ca_file`
 
@@ -899,9 +910,14 @@ available starting at Vault version 1.4.
   - Comma-separated list of source IPs for which PROXY protocol information will be used.
 - Default value: ""
 
-### `vault_tls_config_path`
+### `vault_tls_certs_path`
 
-- Path to TLS certificate and key
+- Path to TLS certificates
+- Default value `/etc/vault/tls`
+
+### `vault_tls_private_path`
+
+- Path to TLS keys
 - Default value `/etc/vault/tls`
 
 ### `vault_tls_disable`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,7 +96,8 @@ vault_tcp_listeners:
     # vault_proxy_protocol_behavior: '{{ vault_proxy_protocol_behavior }}'
     # vault_proxy_protocol_authorized_addrs: '{{ vault_proxy_protocol_authorized_addrs }}'
     vault_tls_disable: '{{ vault_tls_disable }}'
-    vault_tls_config_path: '{{ vault_tls_config_path }}'
+    vault_tls_certs_path: '{{ vault_tls_certs_path }}'
+    vault_tls_private_path: '{{ vault_tls_private_path }}'
     vault_tls_cert_file: '{{ vault_tls_cert_file }}'
     vault_tls_key_file: '{{ vault_tls_key_file }}'
     vault_tls_ca_file: '{{ vault_tls_ca_file }}'
@@ -134,7 +135,8 @@ vault_default_lease_ttl: "768h"
 
 # Storage tls settings
 vault_backend_tls_src_files: "{{ vault_tls_src_files }}"
-vault_backend_tls_config_path: "{{ vault_tls_config_path }}"
+vault_backend_tls_certs_path: "{{ vault_tls_certs_path }}"
+vault_backend_tls_private_path: "{{ vault_tls_private_path }}"
 vault_backend_tls_cert_file: "{{ vault_tls_cert_file }}"
 vault_backend_tls_key_file: "{{ vault_tls_key_file }}"
 vault_backend_tls_ca_file: "{{ vault_tls_ca_file }}"
@@ -247,7 +249,8 @@ vault_service_registration_consul_scheme: http
 # vault_service_registration_consul_token:
 
 # Consul service registration tls settings
-vault_service_registration_consul_tls_config_path: "{{ vault_tls_config_path }}"
+vault_service_registration_consul_tls_certs_path: "{{ vault_tls_certs_path }}"
+vault_service_registration_consul_tls_private_path: "{{ vault_tls_private_path }}"
 vault_service_registration_consul_tls_cert_file: "{{ vault_tls_cert_file }}"
 vault_service_registration_consul_tls_key_file: "{{ vault_tls_key_file }}"
 vault_service_registration_consul_tls_ca_file: "{{ vault_tls_ca_file }}"
@@ -279,8 +282,9 @@ vault_systemd_unit_path: /lib/systemd/system
 # self-signed certificates you might need to change the following to false
 validate_certs_during_api_reachable_check: true
 
-vault_tls_config_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
-vault_tls_src_files: "{{ lookup('env', 'VAULT_TLS_SRC_FILES') | default(role_path + '/files', true) }}"
+vault_tls_certs_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
+vault_tls_private_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
+vault_tls_src_files: "{{ lookup('env', 'VAULT_TLS_SRC_FILES') | default(role_path+'/files', true) }}"
 
 vault_tls_disable: "{{ lookup('env', 'VAULT_TLS_DISABLE') | default(1, true) }}"
 vault_tls_gossip: "{{ lookup('env', 'VAULT_TLS_GOSSIP') | default(0, true) }}"

--- a/tasks/backend_tls.yml
+++ b/tasks/backend_tls.yml
@@ -10,7 +10,9 @@
     group: "{{ vault_group }}"
     mode: 0700
   with_items:
-    - "{{ vault_backend_tls_config_path }}"
+    - "{{ vault_backend_tls_certs_path }}"
+    - "{{ vault_backend_tls_private_path }}"
+  when: vault_tls_copy_keys | bool
   tags:
     - tls
 
@@ -24,15 +26,15 @@
     group: "{{ vault_group }}"
     mode: "{{ item.mode }}"
   with_items:
+    - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_ca_file }}"
+      dest: "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
+      mode: "0644"
     - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_cert_file }}"
-      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+      dest: "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
       mode: "0644"
     - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_key_file }}"
-      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
+      dest: "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
       mode: "0600"
-    - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_ca_file }}"
-      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
-      mode: "0644"
   when: vault_tls_copy_keys | bool
   tags:
     - tls

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -349,7 +349,7 @@
   lineinfile:
     path: "{{ vault_home }}/{{ vault_dotfile }}"
     regexp: "^export VAULT_CACERT="
-    line: "export VAULT_CACERT={{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+    line: "export VAULT_CACERT={{ vault_tls_certs_path }}/{{ vault_tls_ca_file }}"
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
     create: true

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -10,7 +10,9 @@
     group: "{{ vault_group }}"
     mode: 0750
   with_items:
-    - "{{ vault_tls_config_path }}"
+    - "{{ vault_tls_certs_path }}"
+    - "{{ vault_tls_private_path }}"
+  when: vault_tls_copy_keys | bool
   tags:
     - tls
 
@@ -24,15 +26,15 @@
     group: "{{ vault_group }}"
     mode: "{{ item.mode }}"
   with_items:
+    - src: "{{ vault_tls_src_files }}/{{ vault_tls_ca_file }}"
+      dest: "{{ vault_tls_certs_path }}/{{ vault_tls_ca_file }}"
+      mode: "0644"
     - src: "{{ vault_tls_src_files }}/{{ vault_tls_cert_file }}"
-      dest: "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
+      dest: "{{ vault_tls_certs_path }}/{{ vault_tls_cert_file }}"
       mode: "0644"
     - src: "{{ vault_tls_src_files }}/{{ vault_tls_key_file }}"
-      dest: "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
+      dest: "{{ vault_tls_private_path }}/{{ vault_tls_key_file }}"
       mode: "0600"
-    - src: "{{ vault_tls_src_files }}/{{ vault_tls_ca_file }}"
-      dest: "{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
-      mode: "0644"
   when: vault_tls_copy_keys | bool
   notify:
     - Restart vault

--- a/templates/vault_backend_consul.j2
+++ b/templates/vault_backend_consul.j2
@@ -7,8 +7,8 @@ backend "consul" {
   {% endif %}
   scheme = "{{ vault_consul_scheme }}"
   {% if vault_tls_gossip | bool %}
-  tls_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
-  tls_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
-  tls_ca_file="{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
+  tls_ca_file="{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
+  tls_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
+  tls_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
   {% endif %}
 }

--- a/templates/vault_backend_etcd.j2
+++ b/templates/vault_backend_etcd.j2
@@ -15,9 +15,9 @@ backend "etcd" {
   password = "{{ vault_etcd_password }}"
   {% endif -%}
   {% if vault_tls_gossip | bool -%}
-  tls_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
-  tls_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
-  tls_ca_file="{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
+  tls_ca_file="{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
+  tls_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
+  tls_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
   {% endif -%}
 }
 

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -35,9 +35,9 @@ storage "raft" {
     {% if vault_raft_leader_tls_servername is defined %}
     leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
     {% endif %}
-    leader_ca_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
-    leader_client_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
-    leader_client_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
+    leader_ca_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
+    leader_client_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
+    leader_client_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
   }
     {% else %}
   retry_join {

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -21,9 +21,9 @@ listener "tcp" {
   {% endif -%}
   {% endif -%}
   {% if not (l.vault_tls_disable | bool) -%}
-  tls_cert_file = "{{ l.vault_tls_config_path }}/{{ l.vault_tls_cert_file }}"
-  tls_key_file = "{{ l.vault_tls_config_path }}/{{ l.vault_tls_key_file }}"
-  tls_client_ca_file="{{ l.vault_tls_config_path }}/{{ l.vault_tls_ca_file }}"
+  tls_client_ca_file="{{ l.vault_tls_certs_path }}/{{ l.vault_tls_ca_file }}"
+  tls_cert_file = "{{ l.vault_tls_certs_path }}/{{ l.vault_tls_cert_file }}"
+  tls_key_file = "{{ l.vault_tls_private_path }}/{{ l.vault_tls_key_file }}"
   tls_min_version  = "{{ l.vault_tls_min_version }}"
   {% if vault_tls_cipher_suites is defined and vault_tls_cipher_suites -%}
   tls_cipher_suites = "{{ l.vault_tls_cipher_suites}}"

--- a/templates/vault_seal_transit.j2
+++ b/templates/vault_seal_transit.j2
@@ -14,9 +14,9 @@ seal "transit" {
 {% if vault_transit_tls_skip_verify | bool %}
   tls_skip_verify    = "true"
 {% else %}
-  tls_ca_cert        = "{{ vault_backend_tls_config_path }}/{{ vault_transit_tls_ca_cert_file }}"
-  tls_client_cert    = "{{ vault_backend_tls_config_path }}/{{ vault_transit_tls_client_cert_file }}"
-  tls_client_key     = "{{ vault_backend_tls_config_path }}/{{ vault_transit_tls_client_key_file }}"
+  tls_ca_cert        = "{{ vault_backend_tls_certs_path }}/{{ vault_transit_tls_ca_cert_file }}"
+  tls_client_cert    = "{{ vault_backend_tls_certs_path }}/{{ vault_transit_tls_client_cert_file }}"
+  tls_client_key     = "{{ vault_backend_tls_private_path }}/{{ vault_transit_tls_client_key_file }}"
 {% if vault_transit_tls_server_name is defined %}
   tls_server_name    = "{{ vault_transit_tls_server_name }}"
 {% endif %}

--- a/templates/vault_service_registration_consul.hcl.j2
+++ b/templates/vault_service_registration_consul.hcl.j2
@@ -15,9 +15,9 @@ service_registration "consul" {
   {% endif %}
 
   {% if vault_service_registration_consul_scheme == "https" %}
-  tls_ca_file="{{ vault_service_registration_consul_tls_config_path }}/{{ vault_service_registration_consul_tls_ca_file }}"
-  tls_cert_file = "{{ vault_service_registration_consul_tls_config_path }}/{{ vault_service_registration_consul_tls_cert_file }}"
-  tls_key_file = "{{ vault_service_registration_consul_tls_config_path }}/{{ vault_service_registration_consul_tls_key_file }}"
+  tls_ca_file="{{ vault_service_registration_consul_tls_certs_path }}/{{ vault_service_registration_consul_tls_ca_file }}"
+  tls_cert_file = "{{ vault_service_registration_consul_tls_certs_path }}/{{ vault_service_registration_consul_tls_cert_file }}"
+  tls_key_file = "{{ vault_service_registration_consul_tls_private_path }}/{{ vault_service_registration_consul_tls_key_file }}"
   tls_min_version = "{{ vault_service_registration_consul_tls_min_version }}"
   tls_skip_verify = "{{ vault_service_registration_consul_tls_skip_verify }}"
   {% endif %}


### PR DESCRIPTION
Hosts on which we deploy Vault may already have keys and certificates provided by our certificate authority. As OS usually define separate paths for certificates and keys, this MR allows Vault to make use of them.