### PR TITLE
Stop concatenating spaces in templating logic.

### DIFF
--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -1,51 +1,51 @@
 storage "raft" {
   path = "{{ vault_raft_data_path }}"
   node_id = "{{ vault_raft_node_id }}"
-  {% if vault_raft_performance_multiplier is defined and vault_raft_performance_multiplier %}
+{% if vault_raft_performance_multiplier is defined and vault_raft_performance_multiplier %}
   performance_multiplier = "{{ vault_raft_performance_multiplier }}"
-  {% endif %}
-  {% if vault_raft_trailing_logs is defined and vault_raft_trailing_logs %}
+{% endif %}
+{% if vault_raft_trailing_logs is defined and vault_raft_trailing_logs %}
   trailing_logs = "{{ vault_raft_trailing_logs }}"
-  {% endif %}
-  {% if vault_raft_snapshot_threshold is defined and vault_raft_snapshot_threshold %}
+{% endif %}
+{% if vault_raft_snapshot_threshold is defined and vault_raft_snapshot_threshold %}
   snapshot_threshold = "{{ vault_raft_snapshot_threshold }}"
-  {% endif %}
-  {% if vault_raft_max_entry_size is defined and vault_raft_max_entry_size %}
+{% endif %}
+{% if vault_raft_max_entry_size is defined and vault_raft_max_entry_size %}
   max_entry_size = "{{ vault_raft_max_entry_size }}"
-  {% endif %}
-  {% if vault_raft_autopilot_reconcile_interval is defined and vault_raft_autopilot_reconcile_interval %}
+{% endif %}
+{% if vault_raft_autopilot_reconcile_interval is defined and vault_raft_autopilot_reconcile_interval %}
   autopilot_reconcile_interval = "{{ vault_raft_autopilot_reconcile_interval }}"
-  {% endif %}
-  {% if vault_raft_cloud_auto_join is defined and vault_raft_cloud_auto_join %}
+{% endif %}
+{% if vault_raft_cloud_auto_join is defined and vault_raft_cloud_auto_join %}
   retry_join {
     auto_join = "{{ vault_raft_cloud_auto_join }}"
-    {% if vault_raft_cloud_auto_join_scheme is defined and vault_raft_cloud_auto_join_scheme %}
+{% if vault_raft_cloud_auto_join_scheme is defined and vault_raft_cloud_auto_join_scheme %}
     auto_join_scheme = "{{ vault_raft_cloud_auto_join_scheme }}"
-    {% endif %}
-    {% if vault_raft_cloud_auto_join_port is defined and vault_raft_cloud_auto_join_port %}
+{% endif %}
+{% if vault_raft_cloud_auto_join_port is defined and vault_raft_cloud_auto_join_port %}
     auto_join_port = "{{ vault_raft_cloud_auto_join_port }}"
-    {% endif %}
+{% endif %}
   }
-  {% endif %}
-  {% if not vault_raft_cloud_auto_join_exclusive %}
-  {% for raft_peer in vault_raft_cluster_members | rejectattr('peer', 'equalto', inventory_hostname) %}
-    {% if not (vault_tls_disable | bool) %}
+{% endif %}
+{% if not vault_raft_cloud_auto_join_exclusive %}
+{% for raft_peer in vault_raft_cluster_members | rejectattr('peer', 'equalto', inventory_hostname) %}
+{% if not (vault_tls_disable | bool) %}
   retry_join {
     leader_api_addr = "{{ raft_peer.api_addr }}"
-    {% if vault_raft_leader_tls_servername is defined %}
+{% if vault_raft_leader_tls_servername is defined %}
     leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
-    {% endif %}
+{% endif %}
     leader_ca_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
     leader_client_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
     leader_client_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
   }
-    {% else %}
+{% else %}
   retry_join {
     leader_api_addr =  "{{ raft_peer.api_addr }}"
   }
-    {% endif %}
-  {% endfor %}
-  {% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 }
 
 // HashiCorp recommends disabling mlock when using Raft.


### PR DESCRIPTION
The spaces before each template block are adding together to make the final product output file indenting excessive. Opting here for final readability instead of templating readability.