### PR TITLE
feat: add support for installing vault plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use git tag in the version attribute. Also you can honor its legacy `nam
 
 ## Requirements
 
-This role requires Archlinux, or FreeBSD, or a Debian or RHEL based Linux distribution. It
+This role requires Archlinux, AmazonLinux, FreeBSD, Debian or a RHEL based Linux distribution. It
 might work with other software versions, but does work with the following
 specific software and versions:
 
@@ -189,6 +189,30 @@ The role defines variables in `defaults/main.yml`:
 
 - Path from where plugins can be loaded
 - Default value: `/usr/local/lib/vault/plugins`
+
+### `vault_plugins_enable`
+
+- List of plugins to enable (Check uner `tasks/plugins` to see supported plugins.)
+- For example: `vault_plugins_enable: [ 'acme', 'example' ]`
+- Default value: `[]`
+
+### `vault_plugins_src_dir_remote`
+
+- Directory where temporary plugin zip/installation files are placed.
+  When installation is processed remotely.
+- Default value: `/usr/local/src/vault/plugins`
+
+### `vault_plugins_src_dir_local`
+
+- Directory where temporary plugin zip/installation files are placed.
+  When installation is processed locally.
+- Default value: `{{ role_path }}/files/plugins`
+
+### `vault_plugins_src_dir_cleanup`
+
+- Whether to clean up the temporary plugin zip/installation file directory after plugin install.
+  Warning: When plugins don't provide a version number this could cause the plugins to be downloaded every time and thus breaking idempotence.
+- Default value: `false`
 
 ### `vault_data_path`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -381,3 +381,11 @@ vault_license_path: "{{ vault_config_path }}/license.hclic"
 # Path to enterprise license on the Ansible controller (source file for upload)
 # Upload skipped when empty or undefined
 vault_license_file: ""
+
+# -----------------
+# Vault plugins
+# -----------------
+vault_plugins_enable: []
+vault_plugins_src_dir_remote: /usr/local/src/vault/plugins  # Directory for storing vault plugin src/zip files on target hosts
+vault_plugins_src_dir_local: "{{ role_path }}/files/plugins"  # Directory for storing vault plugin src/zip files locally
+vault_plugins_src_dir_cleanup: false  # Cleanup vault plugin src/zip dir after plugin install. WARNING: could cause plugins to be downloaded each time.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -402,7 +402,7 @@
                      default(vault_tls_disable | ternary('http', 'https') ~ '://' ~ vault_addr ~ ':' ~ vault_port, true) }}"
         VAULT_CACERT: "{{ lookup('env', 'VAULT_CACERT') |
                        default(vault_tls_config_path ~ '/' ~ vault_tls_ca_file if not (vault_tls_disable) else '', true) }}"
-        VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') }}"
+        VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') | default(lookup('file', '~/.vault-token', errors='ignore')) }}"
 
 - name: Vault status
   debug:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -389,6 +389,21 @@
   when:
     - not vault_disable_api_health_check | bool
 
+- name: Install/configure vault plugins
+  include_tasks: "plugins/{{ _index_plugin }}.yml"
+  loop: "{{ ('molecule-notest' not in ansible_skip_tags) | ternary(vault_plugins_enable,
+         lookup('fileglob', 'tasks/plugins/*.yml', wantlist=true) | map('basename') | map('splitext') | map('first')) }}"
+  loop_control:
+    loop_var: _index_plugin
+  args:
+    apply:
+      environment:
+        VAULT_ADDR: "{{ lookup('env', 'VAULT_ADDR') |
+                     default(vault_tls_disable | ternary('http', 'https') ~ '://' ~ vault_addr ~ ':' ~ vault_port, true) }}"
+        VAULT_CACERT: "{{ lookup('env', 'VAULT_CACERT') |
+                       default(vault_tls_config_path ~ '/' ~ vault_tls_ca_file if not (vault_tls_disable) else '', true) }}"
+        VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') }}"
+
 - name: Vault status
   debug:
     msg: "Vault is {{ vault_http_status[check_result.status | string] }}"


### PR DESCRIPTION
Adds support for installing vault plugins.
A playbook for each plugin should be placed under `tasks/plugins`.
Then the plugin can be enabled by adding them to the `vault_plugins_enable` list. By default all of the available plugin playbooks are enabled when running a molecule test.

See #316 for a example on how to add a plugin.