### PR TITLE
feat: add acme plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## NEXT
 
 - Add support for proxy configuration
-- Add support for system certificates with `vault_tls_certs_path` and `vault_tls_private_path`
 
 ## v2.5.3
 - Add Prometheus telemetry support (thanks @bbayszczak)

--- a/README.md
+++ b/README.md
@@ -1507,6 +1507,25 @@ This feature enabled operators to delegate the unsealing process to AZURE Key Va
 - The key hosted in the Vault in Azure Key Vault
 - Default value: vault_key
 
+## Vault plugins
+
+### acme plugin
+
+Installs vault-acme plugin, also enables the plugin if authenticated against vault (`VAULT_ADDR`, `VAULT_TOKEN` env).
+
+#### `vault_plugin_acme_install`
+- Setting this to `remote` will download the acme plugin to each target instead of copying it from localhost.
+- Choices: remote / local
+- Default value: `remote`
+
+#### `vault_plugin_acme_sidecar_install'
+- Whether to install vault acme sidecar for `HTTP-01`/`TLS_ALPN_01` challenges in addition to DNS-01.
+- Default value: `false`
+
+#### `vault_plugin_acme_version'
+- Version of the acme plugin to install, can be set to `latest` for obtaining the latest available version.
+- Default value: `latest`
+
 ## License
 
 BSD-2-Clause

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use git tag in the version attribute. Also you can honor its legacy `nam
 
 ## Requirements
 
-This role requires Archlinux, or FreeBSD, or a Debian or RHEL based Linux distribution. It
+This role requires Archlinux, AmazonLinux, FreeBSD, Debian or a RHEL based Linux distribution. It
 might work with other software versions, but does work with the following
 specific software and versions:
 
@@ -189,6 +189,30 @@ The role defines variables in `defaults/main.yml`:
 
 - Path from where plugins can be loaded
 - Default value: `/usr/local/lib/vault/plugins`
+
+### `vault_plugins_enable`
+
+- List of plugins to enable (Check uner `tasks/plugins` to see supported plugins.)
+- For example: `vault_plugins_enable: [ 'acme', 'example' ]`
+- Default value: `[]`
+
+### `vault_plugins_src_dir_remote`
+
+- Directory where temporary plugin zip/installation files are placed.
+  When installation is processed remotely.
+- Default value: `/usr/local/src/vault/plugins`
+
+### `vault_plugins_src_dir_local`
+
+- Directory where temporary plugin zip/installation files are placed.
+  When installation is processed locally.
+- Default value: `{{ role_path }}/files/plugins`
+
+### `vault_plugins_src_dir_cleanup`
+
+- Whether to clean up the temporary plugin zip/installation file directory after plugin install.
+  Warning: When plugins don't provide a version number this could cause the plugins to be downloaded every time and thus breaking idempotence.
+- Default value: `false`
 
 ### `vault_data_path`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use git tag in the version attribute. Also you can honor its legacy `nam
 
 ## Requirements
 
-This role requires Archlinux, AmazonLinux, FreeBSD, Debian or a RHEL based Linux distribution. It
+This role requires Archlinux, or FreeBSD, or a Debian or RHEL based Linux distribution. It
 might work with other software versions, but does work with the following
 specific software and versions:
 
@@ -190,30 +190,6 @@ The role defines variables in `defaults/main.yml`:
 - Path from where plugins can be loaded
 - Default value: `/usr/local/lib/vault/plugins`
 
-### `vault_plugins_enable`
-
-- List of plugins to enable (Check uner `tasks/plugins` to see supported plugins.)
-- For example: `vault_plugins_enable: [ 'acme', 'example' ]`
-- Default value: `[]`
-
-### `vault_plugins_src_dir_remote`
-
-- Directory where temporary plugin zip/installation files are placed.
-  When installation is processed remotely.
-- Default value: `/usr/local/src/vault/plugins`
-
-### `vault_plugins_src_dir_local`
-
-- Directory where temporary plugin zip/installation files are placed.
-  When installation is processed locally.
-- Default value: `{{ role_path }}/files/plugins`
-
-### `vault_plugins_src_dir_cleanup`
-
-- Whether to clean up the temporary plugin zip/installation file directory after plugin install.
-  Warning: When plugins don't provide a version number this could cause the plugins to be downloaded every time and thus breaking idempotence.
-- Default value: `false`
-
 ### `vault_data_path`
 
 - Data path
@@ -306,8 +282,7 @@ vault_tcp_listeners:
     # vault_proxy_protocol_behavior: '{{ vault_proxy_protocol_behavior }}'
     # vault_proxy_protocol_authorized_addrs: '{{ vault_proxy_protocol_authorized_addrs }}'
     vault_tls_disable: '{{ vault_tls_disable }}'
-    vault_tls_certs_path: '{{ vault_tls_certs_path }}'
-    vault_tls_private_path: '{{ vault_tls_private_path }}'
+    vault_tls_config_path: '{{ vault_tls_config_path }}'
     vault_tls_cert_file: '{{ vault_tls_cert_file }}'
     vault_tls_key_file: '{{ vault_tls_key_file }}'
     vault_tls_ca_file: '{{ vault_tls_ca_file }}'
@@ -335,15 +310,10 @@ vault_tcp_listeners:
 - User-specified source directory for TLS files for storage communication
 - {{ vault_tls_src_files }}
 
-### `vault_backend_tls_certs_path`
+### `vault_backend_tls_config_path`
 
-- Path to directory containing backend tls certificate files
-- {{ vault_tls_certs_path }}
-
-### `vault_backend_tls_private_path`
-
-- Path to directory containing backend tls key files
-- {{ vault_tls_private_path }}
+- Path to directory containing backend tls config files
+- {{ vault_tls_config_path }}
 
 ### `vault_backend_tls_cert_file`
 
@@ -770,15 +740,10 @@ starting at Vault version 1.4.
 - ACL token for registering with Consul service registration
 - Default value: none
 
-#### `vault_service_registration_consul_tls_certs_path`
+#### `vault_service_registration_consul_tls_config_path`
 
-- path to tls certificate
-- default value `{{ vault_tls_certs_path }}`
-
-#### `vault_service_registration_consul_tls_private_path`
-
-- path to tls key
-- default value `{{ vault_tls_private_path }}`
+- Path to TLS certificate and key
+- Default value `{{ vault_tls_config_path }}`
 
 #### `vault_service_registration_consul_tls_ca_file`
 
@@ -934,14 +899,9 @@ available starting at Vault version 1.4.
   - Comma-separated list of source IPs for which PROXY protocol information will be used.
 - Default value: ""
 
-### `vault_tls_certs_path`
+### `vault_tls_config_path`
 
-- Path to TLS certificates
-- Default value `/etc/vault/tls`
-
-### `vault_tls_private_path`
-
-- Path to TLS keys
+- Path to TLS certificate and key
 - Default value `/etc/vault/tls`
 
 ### `vault_tls_disable`

--- a/README.md
+++ b/README.md
@@ -1558,11 +1558,11 @@ Installs vault-acme plugin, also enables the plugin if authenticated against vau
 - Choices: remote / local
 - Default value: `remote`
 
-#### `vault_plugin_acme_sidecar_install'
+#### `vault_plugin_acme_sidecar_install`
 - Whether to install vault acme sidecar for `HTTP-01`/`TLS_ALPN_01` challenges in addition to DNS-01.
 - Default value: `false`
 
-#### `vault_plugin_acme_version'
+#### `vault_plugin_acme_version`
 - Version of the acme plugin to install, can be set to `latest` for obtaining the latest available version.
 - Default value: `latest`
 

--- a/README.md
+++ b/README.md
@@ -1558,11 +1558,11 @@ Installs vault-acme plugin, also enables the plugin if authenticated against vau
 - Choices: remote / local
 - Default value: `remote`
 
-#### `vault_plugin_acme_sidecar_install`
+#### `vault_plugin_acme_sidecar_install'
 - Whether to install vault acme sidecar for `HTTP-01`/`TLS_ALPN_01` challenges in addition to DNS-01.
 - Default value: `false`
 
-#### `vault_plugin_acme_version`
+#### `vault_plugin_acme_version'
 - Version of the acme plugin to install, can be set to `latest` for obtaining the latest available version.
 - Default value: `latest`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,8 +96,7 @@ vault_tcp_listeners:
     # vault_proxy_protocol_behavior: '{{ vault_proxy_protocol_behavior }}'
     # vault_proxy_protocol_authorized_addrs: '{{ vault_proxy_protocol_authorized_addrs }}'
     vault_tls_disable: '{{ vault_tls_disable }}'
-    vault_tls_certs_path: '{{ vault_tls_certs_path }}'
-    vault_tls_private_path: '{{ vault_tls_private_path }}'
+    vault_tls_config_path: '{{ vault_tls_config_path }}'
     vault_tls_cert_file: '{{ vault_tls_cert_file }}'
     vault_tls_key_file: '{{ vault_tls_key_file }}'
     vault_tls_ca_file: '{{ vault_tls_ca_file }}'
@@ -135,8 +134,7 @@ vault_default_lease_ttl: "768h"
 
 # Storage tls settings
 vault_backend_tls_src_files: "{{ vault_tls_src_files }}"
-vault_backend_tls_certs_path: "{{ vault_tls_certs_path }}"
-vault_backend_tls_private_path: "{{ vault_tls_private_path }}"
+vault_backend_tls_config_path: "{{ vault_tls_config_path }}"
 vault_backend_tls_cert_file: "{{ vault_tls_cert_file }}"
 vault_backend_tls_key_file: "{{ vault_tls_key_file }}"
 vault_backend_tls_ca_file: "{{ vault_tls_ca_file }}"
@@ -249,8 +247,7 @@ vault_service_registration_consul_scheme: http
 # vault_service_registration_consul_token:
 
 # Consul service registration tls settings
-vault_service_registration_consul_tls_certs_path: "{{ vault_tls_certs_path }}"
-vault_service_registration_consul_tls_private_path: "{{ vault_tls_private_path }}"
+vault_service_registration_consul_tls_config_path: "{{ vault_tls_config_path }}"
 vault_service_registration_consul_tls_cert_file: "{{ vault_tls_cert_file }}"
 vault_service_registration_consul_tls_key_file: "{{ vault_tls_key_file }}"
 vault_service_registration_consul_tls_ca_file: "{{ vault_tls_ca_file }}"
@@ -282,9 +279,8 @@ vault_systemd_unit_path: /lib/systemd/system
 # self-signed certificates you might need to change the following to false
 validate_certs_during_api_reachable_check: true
 
-vault_tls_certs_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
-vault_tls_private_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
-vault_tls_src_files: "{{ lookup('env', 'VAULT_TLS_SRC_FILES') | default(role_path+'/files', true) }}"
+vault_tls_config_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
+vault_tls_src_files: "{{ lookup('env', 'VAULT_TLS_SRC_FILES') | default(role_path + '/files', true) }}"
 
 vault_tls_disable: "{{ lookup('env', 'VAULT_TLS_DISABLE') | default(1, true) }}"
 vault_tls_gossip: "{{ lookup('env', 'VAULT_TLS_GOSSIP') | default(0, true) }}"
@@ -386,13 +382,9 @@ vault_license_path: "{{ vault_config_path }}/license.hclic"
 # Upload skipped when empty or undefined
 vault_license_file: ""
 
-# Vault plugins
-vault_plugins_enable: []
-vault_plugins_src_dir_remote: /usr/local/src/vault/plugins  # Directory for storing vault plugin src/zip files on target hosts
-vault_plugins_src_dir_local: "{{ role_path }}/files/plugins"  # Directory for storing vault plugin src/zip files locally
-vault_plugins_src_dir_cleanup: false  # Cleanup vault plugin src/zip dir after plugin install. WARNING: could cause plugins to be downloaded each time.
-
+# -----------------
 # vault acme plugin
+# -----------------
 vault_plugin_acme_install: remote  # remote / local
 vault_plugin_acme_sidecar_install: false
 vault_plugin_acme_version: "latest"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -381,3 +381,14 @@ vault_license_path: "{{ vault_config_path }}/license.hclic"
 # Path to enterprise license on the Ansible controller (source file for upload)
 # Upload skipped when empty or undefined
 vault_license_file: ""
+
+# -----------------
+# vault acme plugin
+# -----------------
+vault_plugin_acme_install: remote  # remote / local
+vault_plugin_acme_sidecar_install: false
+vault_plugin_acme_version: "latest"
+vault_plugin_acme_zip: "{{ vault_os }}_{{ vault_architecture }}.zip"
+vault_plugin_acme_release_url: "https://github.com/remilapeyre/vault-acme/releases/download/v{{ vault_plugin_acme_version }}"
+vault_plugin_acme_zip_sha256sum: "{{ (lookup('url', vault_plugin_acme_release_url ~ '/vault-acme_SHA256SUMS',
+                              wantlist=true) | select('match', '.*' + vault_plugin_acme_zip + '$') | first).split()[0] }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -381,3 +381,11 @@ vault_license_path: "{{ vault_config_path }}/license.hclic"
 # Path to enterprise license on the Ansible controller (source file for upload)
 # Upload skipped when empty or undefined
 vault_license_file: ""
+
+# -----------------
+# Vault plugins
+# -----------------
+vault_plugins_enable: []
+vault_plugins_src_dir_remote: /usr/local/src/vault/plugins  # Directory for storing vault plugin src/zip files on target hosts
+vault_plugins_src_dir_local: "{{ role_path }}/files/plugins"  # Directory for storing vault plugin src/zip files locally
+vault_plugins_src_dir_cleanup: false  # Cleanup vault plugin src/zip dir after plugin install. WARNING: could cause plugins to be downloaded each time.

--- a/tasks/backend_tls.yml
+++ b/tasks/backend_tls.yml
@@ -10,9 +10,7 @@
     group: "{{ vault_group }}"
     mode: 0700
   with_items:
-    - "{{ vault_backend_tls_certs_path }}"
-    - "{{ vault_backend_tls_private_path }}"
-  when: vault_tls_copy_keys | bool
+    - "{{ vault_backend_tls_config_path }}"
   tags:
     - tls
 
@@ -26,15 +24,15 @@
     group: "{{ vault_group }}"
     mode: "{{ item.mode }}"
   with_items:
-    - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_ca_file }}"
-      dest: "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
-      mode: "0644"
     - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_cert_file }}"
-      dest: "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
+      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
       mode: "0644"
     - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_key_file }}"
-      dest: "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
+      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
       mode: "0600"
+    - src: "{{ vault_backend_tls_src_files }}/{{ vault_backend_tls_ca_file }}"
+      dest: "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
+      mode: "0644"
   when: vault_tls_copy_keys | bool
   tags:
     - tls

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -389,6 +389,21 @@
   when:
     - not vault_disable_api_health_check | bool
 
+- name: Install/configure vault plugins
+  include_tasks: "plugins/{{ _index_plugin }}.yml"
+  loop: "{{ ('molecule-notest' not in ansible_skip_tags) | ternary(vault_plugins_enable,
+         lookup('fileglob', 'tasks/plugins/*.yml', wantlist=true) | map('basename') | map('splitext') | map('first')) }}"
+  loop_control:
+    loop_var: _index_plugin
+  args:
+    apply:
+      environment:
+        VAULT_ADDR: "{{ lookup('env', 'VAULT_ADDR') |
+                     default(vault_tls_disable | ternary('http', 'https') ~ '://' ~ vault_addr ~ ':' ~ vault_port, true) }}"
+        VAULT_CACERT: "{{ lookup('env', 'VAULT_CACERT') |
+                       default(vault_tls_config_path ~ '/' ~ vault_tls_ca_file if not (vault_tls_disable) else '', true) }}"
+        VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') }}"
+
 - name: Vault status
   debug:
     msg: "Vault is {{ vault_http_status[check_result.status | string] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -349,7 +349,7 @@
   lineinfile:
     path: "{{ vault_home }}/{{ vault_dotfile }}"
     regexp: "^export VAULT_CACERT="
-    line: "export VAULT_CACERT={{ vault_tls_certs_path }}/{{ vault_tls_ca_file }}"
+    line: "export VAULT_CACERT={{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
     owner: "{{ vault_user }}"
     group: "{{ vault_group }}"
     create: true
@@ -388,21 +388,6 @@
     - check_vault
   when:
     - not vault_disable_api_health_check | bool
-
-- name: Install/configure vault plugins
-  include_tasks: "plugins/{{ _index_plugin }}.yml"
-  loop: "{{ ('molecule-notest' not in ansible_skip_tags) | ternary(vault_plugins_enable,
-         lookup('fileglob', 'tasks/plugins/*.yml', wantlist=true) | map('basename') | map('splitext') | map('first')) }}"
-  loop_control:
-    loop_var: _index_plugin
-  args:
-    apply:
-      environment:
-        VAULT_ADDR: "{{ lookup('env', 'VAULT_ADDR') |
-                     default(vault_tls_disable | ternary('http', 'https') ~ '://' ~ vault_addr ~ ':' ~ vault_port, true) }}"
-        VAULT_CACERT: "{{ lookup('env', 'VAULT_CACERT') |
-                       default(vault_tls_config_path ~ '/' ~ vault_tls_ca_file if not (vault_tls_disable) else '', true) }}"
-        VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') }}"
 
 - name: Vault status
   debug:

--- a/tasks/plugins/acme.yml
+++ b/tasks/plugins/acme.yml
@@ -30,6 +30,7 @@
         - name: Download acme vault plugin
           get_url:
             url: "{{ vault_plugin_acme_release_url }}/{{ vault_plugin_acme_zip }}"
+            # url: "https://{{ vault_plugin_acme_url }}/releases/download/v{{ vault_plugin_acme_version }}/{{ vault_plugin_acme_zip }}"
             dest: "{{ __vault_plugin_acme_zip_dir.path }}"
             checksum: "sha256:{{ vault_plugin_acme_zip_sha256sum }}"
             mode: 0644

--- a/tasks/plugins/acme.yml
+++ b/tasks/plugins/acme.yml
@@ -30,7 +30,6 @@
         - name: Download acme vault plugin
           get_url:
             url: "{{ vault_plugin_acme_release_url }}/{{ vault_plugin_acme_zip }}"
-            # url: "https://{{ vault_plugin_acme_url }}/releases/download/v{{ vault_plugin_acme_version }}/{{ vault_plugin_acme_zip }}"
             dest: "{{ __vault_plugin_acme_zip_dir.path }}"
             checksum: "sha256:{{ vault_plugin_acme_zip_sha256sum }}"
             mode: 0644

--- a/tasks/plugins/acme.yml
+++ b/tasks/plugins/acme.yml
@@ -1,0 +1,111 @@
+---
+- name: Looking up latest version of acme plugin
+  set_fact:
+    vault_plugin_acme_version: "{{ (lookup('url', 'https://api.github.com/repos/remilapeyre/vault-acme/releases', split_lines=false) |
+                                from_json)[0].get('tag_name') | replace('v', '') }}"
+  when: 'vault_plugin_acme_version == "latest"'
+
+- name: Vault acme plugin installation
+  block:
+    - name: Fetch acme vault plugin
+      delegate_to: "{{ (vault_plugin_acme_install == 'local') | ternary('localhost', omit) }}"
+      block:
+        - name: Install dependencies
+          package:
+            name: "{{ vault_os_packages }}"
+            state: present
+          become: true
+          when: (vault_plugin_acme_install == 'remote')
+
+        - name: Create temporary directory for acme vault plugin
+          file:
+            path: "{{ (vault_plugin_acme_install == 'local') | ternary(vault_plugins_src_dir_local, vault_plugins_src_dir_remote) }}/acme"
+            state: directory
+            mode: 0755
+            owner: "{{ (vault_plugin_acme_install == 'local') | ternary(omit, vault_user) }}"
+            group: "{{ (vault_plugin_acme_install == 'local') | ternary(omit, vault_group) }}"
+          register: __vault_plugin_acme_zip_dir
+          run_once: "{{ (vault_plugin_acme_install == 'local') }}"
+
+        - name: Download acme vault plugin
+          get_url:
+            url: "{{ vault_plugin_acme_release_url }}/{{ vault_plugin_acme_zip }}"
+            # url: "https://{{ vault_plugin_acme_url }}/releases/download/v{{ vault_plugin_acme_version }}/{{ vault_plugin_acme_zip }}"
+            dest: "{{ __vault_plugin_acme_zip_dir.path }}"
+            checksum: "sha256:{{ vault_plugin_acme_zip_sha256sum }}"
+            mode: 0644
+          register: __vault_plugin_acme_zip_file
+          run_once: "{{ (vault_plugin_acme_install == 'local') }}"
+
+        - name: Extract acme vault plugin
+          unarchive:
+            remote_src: "{{ (vault_plugin_acme_install == 'remote') }}"
+            src: "{{ __vault_plugin_acme_zip_file.dest }}"
+            dest: "{{ __vault_plugin_acme_zip_dir.path }}"
+            mode: 0644
+          run_once: "{{ (vault_plugin_acme_install == 'local') }}"
+
+    - name: Install acme vault plugin
+      copy:
+        remote_src: "{{ (vault_plugin_acme_install == 'remote') }}"
+        src: "{{ __vault_plugin_acme_zip_dir.path }}/{{ item.src }}"
+        dest: "{{ item.dest }}"
+        mode: "+x"
+      when: (item.when | default(true))
+      loop:
+        - src: "acme-plugin"
+          dest: "{{ vault_plugin_path }}/acme"
+        - src: "sidecar"
+          dest: "/usr/local/bin/vault-acme-sidecar"
+          when: "{{ vault_plugin_acme_sidecar_install }}"
+
+  always:
+    - name: "Clean up src directory"
+      file:
+        path: "{{ __vault_plugin_acme_zip_dir.path }}"
+        state: absent
+      delegate_to: "{{ (vault_plugin_acme_install == 'local') | ternary('localhost', omit) }}"
+      run_once: "{{ (vault_plugin_acme_install == 'local') }}"
+      when: (vault_plugins_src_dir_cleanup)
+
+- name: "Check vault authentication"
+  command: vault token lookup
+  changed_when: false
+  failed_when: false
+  register: __vault_token_lookup
+  no_log: true
+
+- name: Enable acme plugin
+  when:
+    - (check_result.status == 200)
+    - (__vault_token_lookup.rc == 0)
+  block:
+    - name: "Look up registered acme plugin sha256"
+      command: vault plugin info -field=sha256 secret acme
+      changed_when: false
+      failed_when: false
+      register: __vault_plugin_acme_registered_sha256
+
+    - name: "Get acme plugin sha256sum"
+      stat:
+        path: "{{ vault_plugin_path }}/acme"
+        checksum_algorithm: sha256
+      register: __vault_plugin_acme_sha256sum
+
+    - name: "Register acme plugin in vault catalog"
+      command:
+        cmd: "vault write sys/plugins/catalog/secret/acme
+              sha_256={{ __vault_plugin_acme_sha256sum.stat.checksum }}
+              version={{ vault_plugin_acme_version }} command=acme"
+      become: true
+      become_user: "{{ vault_user }}"
+      register: __vault_write_acme
+      changed_when: __vault_write_acme.stdout is search('Success!')
+      when: __vault_plugin_acme_registered_sha256.stdout != __vault_plugin_acme_sha256sum.stat.checksum
+
+    - name: "Enable acme plugin"
+      command:
+        cmd: vault secrets enable -path acme -plugin-name acme plugin
+      register: __vault_plugin_acme_enable
+      changed_when: __vault_plugin_acme_enable.stdout is search('Enabled the acme secrets engine')
+      failed_when: __vault_plugin_acme_enable.stdout is search('plugin not found in the catalog')

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -10,9 +10,7 @@
     group: "{{ vault_group }}"
     mode: 0750
   with_items:
-    - "{{ vault_tls_certs_path }}"
-    - "{{ vault_tls_private_path }}"
-  when: vault_tls_copy_keys | bool
+    - "{{ vault_tls_config_path }}"
   tags:
     - tls
 
@@ -26,15 +24,15 @@
     group: "{{ vault_group }}"
     mode: "{{ item.mode }}"
   with_items:
-    - src: "{{ vault_tls_src_files }}/{{ vault_tls_ca_file }}"
-      dest: "{{ vault_tls_certs_path }}/{{ vault_tls_ca_file }}"
-      mode: "0644"
     - src: "{{ vault_tls_src_files }}/{{ vault_tls_cert_file }}"
-      dest: "{{ vault_tls_certs_path }}/{{ vault_tls_cert_file }}"
+      dest: "{{ vault_tls_config_path }}/{{ vault_tls_cert_file }}"
       mode: "0644"
     - src: "{{ vault_tls_src_files }}/{{ vault_tls_key_file }}"
-      dest: "{{ vault_tls_private_path }}/{{ vault_tls_key_file }}"
+      dest: "{{ vault_tls_config_path }}/{{ vault_tls_key_file }}"
       mode: "0600"
+    - src: "{{ vault_tls_src_files }}/{{ vault_tls_ca_file }}"
+      dest: "{{ vault_tls_config_path }}/{{ vault_tls_ca_file }}"
+      mode: "0644"
   when: vault_tls_copy_keys | bool
   notify:
     - Restart vault

--- a/templates/vault_backend_consul.j2
+++ b/templates/vault_backend_consul.j2
@@ -7,8 +7,8 @@ backend "consul" {
   {% endif %}
   scheme = "{{ vault_consul_scheme }}"
   {% if vault_tls_gossip | bool %}
-  tls_ca_file="{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
-  tls_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
-  tls_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
+  tls_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+  tls_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
+  tls_ca_file="{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
   {% endif %}
 }

--- a/templates/vault_backend_etcd.j2
+++ b/templates/vault_backend_etcd.j2
@@ -15,9 +15,9 @@ backend "etcd" {
   password = "{{ vault_etcd_password }}"
   {% endif -%}
   {% if vault_tls_gossip | bool -%}
-  tls_ca_file="{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
-  tls_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
-  tls_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
+  tls_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+  tls_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
+  tls_ca_file="{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
   {% endif -%}
 }
 

--- a/templates/vault_backend_raft.j2
+++ b/templates/vault_backend_raft.j2
@@ -35,9 +35,9 @@ storage "raft" {
     {% if vault_raft_leader_tls_servername is defined %}
     leader_tls_servername = "{{ vault_raft_leader_tls_servername }}"
     {% endif %}
-    leader_ca_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
-    leader_client_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
-    leader_client_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
+    leader_ca_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_ca_file }}"
+    leader_client_cert_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_cert_file }}"
+    leader_client_key_file = "{{ vault_backend_tls_config_path }}/{{ vault_backend_tls_key_file }}"
   }
     {% else %}
   retry_join {

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -21,9 +21,9 @@ listener "tcp" {
   {% endif -%}
   {% endif -%}
   {% if not (l.vault_tls_disable | bool) -%}
-  tls_client_ca_file="{{ l.vault_tls_certs_path }}/{{ l.vault_tls_ca_file }}"
-  tls_cert_file = "{{ l.vault_tls_certs_path }}/{{ l.vault_tls_cert_file }}"
-  tls_key_file = "{{ l.vault_tls_private_path }}/{{ l.vault_tls_key_file }}"
+  tls_cert_file = "{{ l.vault_tls_config_path }}/{{ l.vault_tls_cert_file }}"
+  tls_key_file = "{{ l.vault_tls_config_path }}/{{ l.vault_tls_key_file }}"
+  tls_client_ca_file="{{ l.vault_tls_config_path }}/{{ l.vault_tls_ca_file }}"
   tls_min_version  = "{{ l.vault_tls_min_version }}"
   {% if vault_tls_cipher_suites is defined and vault_tls_cipher_suites -%}
   tls_cipher_suites = "{{ l.vault_tls_cipher_suites}}"

--- a/templates/vault_seal_transit.j2
+++ b/templates/vault_seal_transit.j2
@@ -14,9 +14,9 @@ seal "transit" {
 {% if vault_transit_tls_skip_verify | bool %}
   tls_skip_verify    = "true"
 {% else %}
-  tls_ca_cert        = "{{ vault_backend_tls_certs_path }}/{{ vault_transit_tls_ca_cert_file }}"
-  tls_client_cert    = "{{ vault_backend_tls_certs_path }}/{{ vault_transit_tls_client_cert_file }}"
-  tls_client_key     = "{{ vault_backend_tls_private_path }}/{{ vault_transit_tls_client_key_file }}"
+  tls_ca_cert        = "{{ vault_backend_tls_config_path }}/{{ vault_transit_tls_ca_cert_file }}"
+  tls_client_cert    = "{{ vault_backend_tls_config_path }}/{{ vault_transit_tls_client_cert_file }}"
+  tls_client_key     = "{{ vault_backend_tls_config_path }}/{{ vault_transit_tls_client_key_file }}"
 {% if vault_transit_tls_server_name is defined %}
   tls_server_name    = "{{ vault_transit_tls_server_name }}"
 {% endif %}

--- a/templates/vault_service_registration_consul.hcl.j2
+++ b/templates/vault_service_registration_consul.hcl.j2
@@ -15,9 +15,9 @@ service_registration "consul" {
   {% endif %}
 
   {% if vault_service_registration_consul_scheme == "https" %}
-  tls_ca_file="{{ vault_service_registration_consul_tls_certs_path }}/{{ vault_service_registration_consul_tls_ca_file }}"
-  tls_cert_file = "{{ vault_service_registration_consul_tls_certs_path }}/{{ vault_service_registration_consul_tls_cert_file }}"
-  tls_key_file = "{{ vault_service_registration_consul_tls_private_path }}/{{ vault_service_registration_consul_tls_key_file }}"
+  tls_ca_file="{{ vault_service_registration_consul_tls_config_path }}/{{ vault_service_registration_consul_tls_ca_file }}"
+  tls_cert_file = "{{ vault_service_registration_consul_tls_config_path }}/{{ vault_service_registration_consul_tls_cert_file }}"
+  tls_key_file = "{{ vault_service_registration_consul_tls_config_path }}/{{ vault_service_registration_consul_tls_key_file }}"
   tls_min_version = "{{ vault_service_registration_consul_tls_min_version }}"
   tls_skip_verify = "{{ vault_service_registration_consul_tls_skip_verify }}"
   {% endif %}


### PR DESCRIPTION
Adds support for installing/enabling [vault-acme](https://github.com/remilapeyre/vault-acme/) plugin.

Depends on: #313 

Can be enabled with:

```yaml
---
vault_plugins_enable:
  - acme
```