### PR TITLE
fix: Skip tls verification for certificate signed by unknown authority

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -146,6 +146,7 @@ vault_consul: 127.0.0.1:8500
 vault_consul_path: vault
 vault_consul_service: vault
 vault_consul_scheme: http
+vault_consul_tls_skip_verify: false
 # vault_consul_token:
 
 # etcd storage settings

--- a/templates/vault_backend_consul.j2
+++ b/templates/vault_backend_consul.j2
@@ -10,5 +10,6 @@ backend "consul" {
   tls_ca_file="{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_ca_file }}"
   tls_cert_file = "{{ vault_backend_tls_certs_path }}/{{ vault_backend_tls_cert_file }}"
   tls_key_file = "{{ vault_backend_tls_private_path }}/{{ vault_backend_tls_key_file }}"
+  tls_skip_verify="{{ vault_consul_tls_skip_verify | bool | lower }}"
   {% endif %}
 }


### PR DESCRIPTION
Vault is not starting when using your own self signed certificate on consul.

```sh
[...]
Oct 29 06:27:19 server01 sh[13549]: 2022-10-29T06:27:19.546Z [WARN]  storage migration check error: error="Get \"https://127.0.0.1:8501/v1/kv/vault/core/migration\": x509: certificate signed by unknown authority"
Oct 29 06:27:21 server01 sh[13549]: 2022-10-29T06:27:21.550Z [WARN]  storage migration check error: error="Get \"https://127.0.0.1:8501/v1/kv/vault/core/migration\": x509: certificate signed by unknown authority"
Oct 29 06:27:23 server01 sh[13549]: 2022-10-29T06:27:23.554Z [WARN]  storage migration check error: error="Get \"https://127.0.0.1:8501/v1/kv/vault/core/migration\": x509: certificate signed by unknown authority"
[...]
```

This fix solved my issue.

It may depends on this [parameter](https://developer.hashicorp.com/vault/docs/configuration/storage/consul#tls_skip_verify). 

Even if it's supposed to be strongly discouraged, for development purpose it is necessary.

