### PR TITLE
fix: only set client_ca_file for tcp listener when defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,11 @@ available starting at Vault version 1.4.
   - Override with `VAULT_TLS_CA_CRT` environment variable
 - Default value: `ca.crt`
 
+### `vault_tls_client_ca_file`
+
+- Client CA certificate filename
+- Default value: ``
+
 ### `vault_tls_cert_file`
 
 - Server certificate

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -293,6 +293,7 @@ vault_protocol: "{% if vault_tls_disable %}http{% else %}https{% endif %}"
 vault_tls_cert_file: "{{ lookup('env', 'VAULT_TLS_CERT_FILE') | default(('tls.crt' if (vault_install_hashi_repo) else 'server.crt'), true) }}"
 vault_tls_key_file: "{{ lookup('env', 'VAULT_TLS_KEY_FILE') | default(('tls.key' if (vault_install_hashi_repo) else 'server.key'), true) }}"
 vault_tls_ca_file: "{{ lookup('env', 'VAULT_TLS_CA_CRT') | default('ca.crt', true) }}"
+vault_tls_client_ca_file: ""
 
 vault_tls_min_version: "{{ lookup('env', 'VAULT_TLS_MIN_VERSION') | default('tls12', true) }}"
 vault_tls_cipher_suites: ""

--- a/templates/vault_main_configuration.hcl.j2
+++ b/templates/vault_main_configuration.hcl.j2
@@ -21,7 +21,9 @@ listener "tcp" {
   {% endif -%}
   {% endif -%}
   {% if not (l.vault_tls_disable | bool) -%}
-  tls_client_ca_file="{{ l.vault_tls_certs_path }}/{{ l.vault_tls_ca_file }}"
+  {% if (l.vault_tls_client_ca_file is defined) -%}
+  tls_client_ca_file="{{ l.vault_tls_certs_path }}/{{ l.vault_tls_client_ca_file }}"
+  {% endif -%}
   tls_cert_file = "{{ l.vault_tls_certs_path }}/{{ l.vault_tls_cert_file }}"
   tls_key_file = "{{ l.vault_tls_private_path }}/{{ l.vault_tls_key_file }}"
   tls_min_version  = "{{ l.vault_tls_min_version }}"


### PR DESCRIPTION
The [docs](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#tls_client_ca_file) state thast `tls_client_ca_file` in a tcp listener is used for client authentication.

This PR correctly sets the `tls_client_ca_file` only when `vault_tls_client_ca_file` has been defined.