### PR TITLE
fix(ci): failing legacy platforms and delegation issues.

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   discover-scenarios:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       scenarios: ${{ steps.set-scenarios.outputs.scenarios }}
     steps:
@@ -28,7 +28,7 @@ jobs:
           echo "::set-output name=scenarios::$scenarios"
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - discover-scenarios
     strategy:
@@ -48,7 +48,7 @@ jobs:
     needs:
       - lint
       - discover-scenarios
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -283,7 +283,7 @@ validate_certs_during_api_reachable_check: true
 
 vault_tls_certs_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
 vault_tls_private_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
-vault_tls_src_files: "{{ lookup('env', 'VAULT_TLS_SRC_FILES') | default(role_path+'/files', true) }}"
+vault_tls_src_files: "{{ lookup('env', 'VAULT_TLS_SRC_FILES') | default(role_path ~ '/files', true) }}"
 
 vault_tls_disable: "{{ lookup('env', 'VAULT_TLS_DISABLE') | default(1, true) }}"
 vault_tls_gossip: "{{ lookup('env', 'VAULT_TLS_GOSSIP') | default(0, true) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -402,7 +402,7 @@
                      default(vault_tls_disable | ternary('http', 'https') ~ '://' ~ vault_addr ~ ':' ~ vault_port, true) }}"
         VAULT_CACERT: "{{ lookup('env', 'VAULT_CACERT') |
                        default(vault_tls_config_path ~ '/' ~ vault_tls_ca_file if not (vault_tls_disable) else '', true) }}"
-        VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') | default(lookup('file', '~/.vault-token', errors='ignore')) }}"
+        VAULT_TOKEN: "{{ lookup('env', 'VAULT_TOKEN') | default(lookup('file', '~/.vault-token', errors='ignore'), true) }}"
 
 - name: Vault status
   debug:

--- a/tasks/plugins/acme.yml
+++ b/tasks/plugins/acme.yml
@@ -8,7 +8,7 @@
 - name: Vault acme plugin installation
   block:
     - name: Fetch acme vault plugin
-      delegate_to: "{{ (vault_plugin_acme_install == 'local') | ternary('localhost', omit) }}"
+      delegate_to: "{{ (vault_plugin_acme_install == 'local') | ternary('localhost', inventory_hostname) }}"
       block:
         - name: Install dependencies
           package:
@@ -65,7 +65,7 @@
       file:
         path: "{{ __vault_plugin_acme_zip_dir.path }}"
         state: absent
-      delegate_to: "{{ (vault_plugin_acme_install == 'local') | ternary('localhost', omit) }}"
+      delegate_to: "{{ (vault_plugin_acme_install == 'local') | ternary('localhost', inventory_hostname) }}"
       run_once: "{{ (vault_plugin_acme_install == 'local') }}"
       when: (vault_plugins_src_dir_cleanup)
 

--- a/tasks/plugins/acme.yml
+++ b/tasks/plugins/acme.yml
@@ -15,7 +15,9 @@
             name: "{{ vault_os_packages }}"
             state: present
           become: true
-          when: (vault_plugin_acme_install == 'remote')
+          when:
+            - (vault_plugin_acme_install == 'remote')
+            - (vault_os_packages is defined) and (vault_os_packages | length > 0)
 
         - name: Create temporary directory for acme vault plugin
           file:


### PR DESCRIPTION
Fixes failing molecule ci jobs by: 
 - avoiding usage of omit in delegation since it seems to cause issues in some ansible versions.
 - downgrading the github runner from ubuntu-latest (which was recently bumped from 20.04 to 22.04) to ubuntu 20.04 since some of the legacy platforms supported by the role have systemd versions that are incompatible with the ubuntu 22.04 runner. 