### PR TITLE
Retreive correct default iface dev name for raft members by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -213,7 +213,7 @@ vault_raft_cluster_members: |
     {
       "peer": "{{ server }}",
       "api_addr": "{{ hostvars[server]['vault_api_addr'] |
-      default(vault_protocol + '://' + hostvars[server]['ansible_' + vault_iface]['ipv4']['address'] + ':' + (vault_port|string)) }}"
+      default(vault_protocol + '://' + hostvars[server]['ansible_' + hostvars[server]['ansible_default_ipv4']['interface']]['ipv4']['address'] + ':' + (vault_port|string)) }}"
     },
   {% endfor %}
   ]


### PR DESCRIPTION
Currently deployment is failing in case if vault nodes have different default network interface name.
E.x.:
- node1 have default network iface name ens160
- nodes node2 node3 have default network iface name wlp0s20f3

This PR makes default vault_raft_cluster_members work correctly when vault hosts have different device names.
