### PR TITLE
restart according to rolling upgrade instructions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ The role defines variables in `defaults/main.yml`:
 - Should the playbook restart Vault service when needed
 - Default value: true
 
+### `vault_rolling_service_restart`
+
+- Following [HashiCorp's rolling upgrade manual](https://developer.hashicorp.com/vault/tutorials/standard-procedures/sop-upgrade#rolling-upgrade-procedure-for-upgrading-a-single-ha-cluster), restart followers before leader in cluster to minimize downtime
+- Default value: false
+
 ### `vault_service_reload`
 
 - Should the playbook reload Vault service when the main config changes.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,6 +61,7 @@ vault_exec_output: ''
 
 # Handlers
 vault_service_restart: true
+vault_rolling_service_restart: false
 vault_service_reload: false
 
 # ---------------------------------------------------------------------------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,88 @@
 ---
 # handlers file for vault
 
+- name: Identify leader
+  vars:
+    vault_addr_protocol: "{{ vault_tls_disable | ternary('http', 'https') }}"
+  environment:
+    no_proxy: "{{ vault_api_addr | urlsplit('hostname') }}"
+  uri:
+    validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
+    url: "{{ vault_api_addr }}/v1/sys/leader"
+    method: GET
+    body_format: json
+  register: result
+  when: 
+    - vault_service_restart | bool
+    - vault_rolling_service_restart | bool
+  listen: Restart vault
+
+- name: Show leader
+  debug:
+    msg: "leader"
+  when:
+    - result.json.is_self | bool
+    - vault_service_restart | bool
+    - vault_rolling_service_restart | bool
+  listen: Restart vault
+
+- name: Restart followers
+  become: true
+  service:
+    name: vault
+    state: restarted
+  when:
+    - not result.json.is_self | bool
+    - vault_service_restart | bool
+    - vault_rolling_service_restart | bool
+  listen: Restart vault
+
+- name: Wait for followers to become available again
+  vars:
+    vault_addr_protocol: "{{ vault_tls_disable | ternary('http', 'https') }}"
+  environment:
+    no_proxy: "{{ vault_api_addr | urlsplit('hostname') }}"
+  uri:
+    validate_certs: "{{ validate_certs_during_api_reachable_check | bool }}"
+    url: "{{ vault_api_addr }}/v1/sys/health"
+    method: GET
+    # 200 if initialized, unsealed, and active
+    # 429 if unsealed and standby
+    # 472 if data recovery mode replication secondary and active
+    # 473 if performance standby
+    # See: https://www.vaultproject.io/api/system/health.html
+    status_code: 429, 472, 473
+    body_format: json
+  register: check_result
+  retries: 6
+  until: check_result is succeeded
+  delay: 10
+  changed_when: false
+  when:
+    - not result.json.is_self | bool
+    - vault_service_restart | bool
+    - vault_rolling_service_restart | bool
+  listen: Restart vault
+
+- name: Restart leader
+  become: true
+  service:
+    name: vault
+    state: restarted
+  when:
+    - result.json.is_self | bool
+    - vault_service_restart | bool
+    - vault_rolling_service_restart | bool
+  listen: Restart vault
+
 - name: Restart vault
   become: true
   service:
     name: '{{ vault_systemd_service_name }}'
     state: restarted
-  when: vault_service_restart | bool
+  when: 
+    - vault_service_restart | bool
+    - not vault_rolling_service_restart | bool
 
 - name: Reload vault
   become: true


### PR DESCRIPTION
This will add a switch to restart a cluster according to instructions noted in [Rolling Upgrade Procedure for upgrading a single HA cluster](https://developer.hashicorp.com/vault/tutorials/standard-procedures/sop-upgrade#rolling-upgrade-procedure-for-upgrading-a-single-ha-cluster). 

Flow in ansible:
1. Identify if host is a leader
2. If not, restart it
3. Wait until it is available again
4. restart leader

I'm by no means an Ansible expert, I hope this makes sense and this PR is acceptable. As far as I can see it works as expected.