### PR TITLE
Update deprecated set-output

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -24,8 +24,8 @@ jobs:
         id: set-scenarios
         # Find path to all scenarios
         run: |
-          export scenarios="[`for x in $(ls -1 molecule -I _tests -I '*.yml'); do echo "'$x'"; done | tr '\n' ',' | sed '$s/,$//'`]"
-          echo "::set-output name=scenarios::$scenarios"
+          scenarios="[`for x in $(ls -1 molecule -I _tests -I '*.yml'); do echo "'$x'"; done | tr '\n' ',' | sed '$s/,$//'`]"
+          echo "scenarios=$scenarios" >> $GITHUB_OUTPUT
 
   test:
     needs:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands.