### PR TITLE
Bump version to 1.18.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,8 @@
 
 # Package variables
 vault_version_suffix: "{{ '+prem' if vault_enterprise_premium else '' }}{{ '.hsm' if vault_enterprise_premium_hsm else '' }}"
-vault_version: "{{ lookup('env', 'VAULT_VERSION') | default('1.5.5', true) }}{{ vault_version_suffix }}"
+vault_version: "{{ lookup('env', 'VAULT_VERSION') | default('1.18.2', true) }}{{ vault_version_suffix }}"
+vault_version_repo_suffix: "-1"
 vault_architecture_map:
   # this first entry seems... redundant (but it's required for reasons)
   amd64: amd64

--- a/tasks/install_hashi_repo.yml
+++ b/tasks/install_hashi_repo.yml
@@ -72,11 +72,11 @@
   become: true
   vars:
     _vault_repo_pkg: "{% if (ansible_pkg_mgr in ['yum', 'dnf']) %}\
-                  vault-{{ vault_version }}\
+                  vault-{{ vault_version }}{{ vault_version_repo_suffix }}\
                 {% elif (ansible_pkg_mgr == 'apt') %}\
-                  vault={{ vault_version }}\
+                  vault={{ vault_version }}{{ vault_version_repo_suffix }}\
                 {% else %}\
-                  vault={{ vault_version }}\
+                  vault={{ vault_version }}{{ vault_version_repo_suffix }}\
                 {% endif %}"
 
 - name: Mask default Vault config from package


### PR DESCRIPTION
Both the rpm and deb repos have a trailing "-1" etc. after the version. The zip files do not. Therefore I've introduced another suffix.