### PR TITLE
Changed when clause to use vault_tls_disable & vault_tls_gossip as bool instead of int comparison

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -289,8 +289,8 @@ vault_tls_certs_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/
 vault_tls_private_path: "{{ lookup('env', 'VAULT_TLS_DIR') | default(('/opt/vault/tls' if (vault_install_hashi_repo) else '/etc/vault/tls'), true) }}"
 vault_tls_src_files: "{{ lookup('env', 'VAULT_TLS_SRC_FILES') | default(role_path ~ '/files', true) }}"
 
-vault_tls_disable: "{{ lookup('env', 'VAULT_TLS_DISABLE') | default(1, true) }}"
-vault_tls_gossip: "{{ lookup('env', 'VAULT_TLS_GOSSIP') | default(0, true) }}"
+vault_tls_disable: "{{ lookup('env', 'VAULT_TLS_DISABLE') | default(true, true) }}"
+vault_tls_gossip: "{{ lookup('env', 'VAULT_TLS_GOSSIP') | default(false, true) }}"
 
 vault_tls_copy_keys: "{{ false if (vault_install_hashi_repo) else true }}"
 vault_protocol: "{% if vault_tls_disable %}http{% else %}https{% endif %}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,11 +130,11 @@
 
 - name: TLS configuration
   include_tasks: ../tasks/tls.yml
-  when: vault_tls_disable == 0
+  when: not vault_tls_disable | bool
 
 - name: Backend storage TLS configuration
   include_tasks: ../tasks/backend_tls.yml
-  when: vault_tls_gossip == 1
+  when: vault_tls_gossip | bool
 
 - name: "Get content of GCP Credentials from file"
   set_fact:


### PR DESCRIPTION
- Cast variables to bool (in case someone uses env-vars and enters 0 or 1)
- Use bool query in when clause instead of integer comparison, so bool values can be assigned to the variables
- Changed default values of the variables to bool