### PR TITLE
 fix: solve crash if vault_port is set below 1024 by adding CAP_NET_ADMIN 

### DIFF
--- a/role_variables.md
+++ b/role_variables.md
@@ -729,6 +729,8 @@ available starting at Vault version 1.4.
 ## `vault_port`
 
 - TCP port number to on which to listen
+- Setting `vault_port` below 1024 will add the `CAP_NET_BIND_SERVICE` capability to the systemd service
+  - This capability allows an unprivileged user to start a service on a privileged port
 - Default value: 8200
 
 ## `vault_max_lease_ttl`

--- a/templates/vault_service_systemd.j2
+++ b/templates/vault_service_systemd.j2
@@ -21,9 +21,9 @@ PrivateDevices=yes
 SecureBits=keep-caps
 Capabilities=CAP_IPC_LOCK+ep
 {% if systemd_version.stdout is version('230', '>=') %}
-AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK
+AmbientCapabilities=CAP_SYSLOG CAP_IPC_LOCK {{ "CAP_NET_BIND_SERVICE" if vault_port < 1024 }}
 {% endif %}
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK {{ "CAP_NET_BIND_SERVICE" if vault_port < 1024 }}
 NoNewPrivileges=yes
 {% if vault_gcs_copy_sa and vault_gcs_credentials_src_file is defined and vault_gcs_credentials_dst_file|length -%}
 Environment=GOOGLE_APPLICATION_CREDENTIALS={{ vault_gcs_credentials_dst_file }}


### PR DESCRIPTION
Add the possibility the possibility to set vault_port < 1024 without crashing by adding the `CAP_NET_BIND_SERVICE` capability when necessary.