### PR TITLE
Add a way to upload license from variable (not file)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -402,8 +402,13 @@ vault_configure_enterprise_license: false
 # https://www.vaultproject.io/docs/configuration#license_path
 vault_license_path: "{{ vault_config_path }}/license.hclic"
 # Path to enterprise license on the Ansible controller (source file for upload)
-# Upload skipped when empty or undefined
+# Upload skipped when empty or undefined, if `vault_license_file` is also empty or undefined
+# Only used if `vault_configure_enterprise_license: true`
 vault_license_file: ""
+# Value of the enterprise license to use
+# Upload skipped when empty or undefined, if `vault_license_file` is also empty or undefined
+# Only used if `vault_configure_enterprise_license: true`
+vault_license_content: ""
 
 # -----------------
 # Vault plugins

--- a/role_variables.md
+++ b/role_variables.md
@@ -978,11 +978,6 @@ differences across distributions:
 - List of OS packages to install
 - Default value: list
 
-## `vault_pkg`
-
-- Vault package filename
-- Default value: `"{{ vault_version }}_linux_amd64.zip"`
-
 ## `vault_debian_url`
 
 - Vault package download URL

--- a/role_variables.md
+++ b/role_variables.md
@@ -1096,7 +1096,7 @@ The role can configure HSM based instances. Make sure to reference the [HSM supp
 
 ## `vault_configure_enterprise_license`
 
-- Manage enterprise license file with this role. Set to `true` to use `vault_license_path` or `vault_license_file`.
+- Manage enterprise license file with this role. Set to `true` to use `vault_license_path`, and `vault_license_file` or `vault_license_content`.
 - Default value: false
 
 ## `vault_license_path`
@@ -1106,7 +1106,12 @@ The role can configure HSM based instances. Make sure to reference the [HSM supp
 
 ## `vault_license_file`
 
-- Path to enterprise license on the Ansible controller (source file for upload). Upload skipped when empty or undefined. Only used if `vault_configure_enterprise_license: true`.
+- Path to enterprise license on the Ansible controller (source file for upload). Upload skipped when empty or undefined, if `vault_license_content` is also empty or undefined. Only used if `vault_configure_enterprise_license: true`.
+- Default value: ""
+
+## `vault_license_content`
+
+- Value of the enterprise license to use. Upload skipped when empty or undefined, if `vault_license_file` is also empty or undefined. Only used if `vault_configure_enterprise_license: true`.
 - Default value: ""
 
 ## `vault_hsm_app`

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -209,6 +209,18 @@
     - vault_configure_enterprise_license | bool
     - vault_license_file | length > 0
 
+- name: Upload Vault license content to vault_license_path
+  become: true
+  copy:
+    content: "{{ vault_license_content }}"
+    dest: "{{ vault_license_path }}"
+    owner: "{{ vault_user }}"
+    group: "{{ vault_group }}"
+    mode: "{{ vault_harden_file_perms | ternary('0400', '0644') }}"
+  when:
+    - vault_configure_enterprise_license | bool
+    - vault_license_content | length > 0
+
 - name: "Set Exec output to log path when enabled log"
   ansible.builtin.set_fact:
     vault_exec_output: ">> {{ vault_log_path }}/vault.log 2>&1"


### PR DESCRIPTION
I would like to use a variable to define the Vault license. A nice improvement would be to be able to copy a variable's content as the license file on the Vault machines, so a variable named `vault_license_content` is suggested in this PR.